### PR TITLE
Clean-up state management in auth components.

### DIFF
--- a/components/auth/AuthPage.tsx
+++ b/components/auth/AuthPage.tsx
@@ -1,47 +1,12 @@
-import React, { useState, useCallback, useMemo } from "react";
-import dynamic, { DynamicOptions } from "next/dynamic";
+import React from "react";
 
 import AuthPageLayout from "./AuthPageLayout";
-import AuthPageFormContainer from "./AuthPageFormContainer";
-import { Content, ContentComponentProps } from "./types";
-
-const options: DynamicOptions<ContentComponentProps> = {
-  loading: () => <AuthPageFormContainer />,
-  ssr: false
-};
-
-const contentComponents: Record<
-  Content,
-  React.ComponentType<ContentComponentProps> | null
-> = {
-  login: dynamic<ContentComponentProps>(
-    () => import("./LoginFormContent"),
-    options
-  ),
-  forgotPassword: dynamic<ContentComponentProps>(
-    () => import("./RecoverPasswordFormContent"),
-    options
-  ),
-  chooseService: null
-};
+import AuthPageContent from "./AuthPageContent";
 
 const AuthPage: React.FC = () => {
-  const [activeContent, setActiveContent] = useState<Content>("login");
-
-  const navigateToContent = useCallback(
-    (content: Content) => {
-      setActiveContent(content);
-    },
-    [setActiveContent]
-  );
-
-  const Component = useMemo(() => contentComponents[activeContent], [
-    activeContent
-  ]);
-
   return (
     <AuthPageLayout>
-      {Component && <Component navigateToContent={navigateToContent} />}
+      <AuthPageContent />
     </AuthPageLayout>
   );
 };

--- a/components/auth/AuthPageContent.tsx
+++ b/components/auth/AuthPageContent.tsx
@@ -1,0 +1,44 @@
+import React, { useState, useCallback, useMemo } from "react";
+import dynamic, { DynamicOptions } from "next/dynamic";
+
+import AuthPageFormContainer from "./AuthPageFormContainer";
+import { Content, ContentComponentProps } from "./types";
+
+const options: DynamicOptions<ContentComponentProps> = {
+  loading: () => <AuthPageFormContainer />,
+  ssr: false
+};
+
+const contentComponents: Record<
+  Content,
+  React.ComponentType<ContentComponentProps> | null
+> = {
+  login: dynamic<ContentComponentProps>(
+    () => import("./LoginFormContent"),
+    options
+  ),
+  forgotPassword: dynamic<ContentComponentProps>(
+    () => import("./RecoverPasswordFormContent"),
+    options
+  ),
+  chooseService: null
+};
+
+const AuthPageContent: React.FC = () => {
+  const [activeContent, setActiveContent] = useState<Content>("login");
+
+  const navigateToContent = useCallback(
+    (content: Content) => {
+      setActiveContent(content);
+    },
+    [setActiveContent]
+  );
+
+  const Component = useMemo(() => contentComponents[activeContent], [
+    activeContent
+  ]);
+
+  return Component && <Component navigateToContent={navigateToContent} />;
+};
+
+export default AuthPageContent;

--- a/components/auth/AuthPageContent.tsx
+++ b/components/auth/AuthPageContent.tsx
@@ -11,7 +11,7 @@ const options: DynamicOptions<ContentComponentProps> = {
 
 const contentComponents: Record<
   Content,
-  React.ComponentType<ContentComponentProps> | null
+  React.ComponentType<ContentComponentProps>
 > = {
   login: dynamic<ContentComponentProps>(
     () => import("./LoginFormContent"),
@@ -20,8 +20,7 @@ const contentComponents: Record<
   forgotPassword: dynamic<ContentComponentProps>(
     () => import("./RecoverPasswordFormContent"),
     options
-  ),
-  chooseService: null
+  )
 };
 
 const AuthPageContent: React.FC = () => {
@@ -38,7 +37,7 @@ const AuthPageContent: React.FC = () => {
     activeContent
   ]);
 
-  return Component && <Component navigateToContent={navigateToContent} />;
+  return <Component navigateToContent={navigateToContent} />;
 };
 
 export default AuthPageContent;

--- a/components/auth/AuthPageForm.tsx
+++ b/components/auth/AuthPageForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { forwardRef, useState, useCallback } from "react";
 
 import makeStyles from "@material-ui/core/styles/makeStyles";
 
@@ -30,68 +30,68 @@ const useStyles = makeStyles({
   }
 });
 
-interface Props {
+type Props = {
   title: string;
   ctaText: string;
   onPressCTA: (stopLoading: () => void) => Promise<void>;
   footer?: React.ReactNode;
-}
+} & React.ComponentProps<typeof AuthPageFormContainer>;
 
-const AuthPageForm: React.FC<
-  Props & React.ComponentProps<typeof AuthPageFormContainer>
-> = ({ children, title, onPressCTA, ctaText, footer, ...rest }) => {
-  const {
-    form,
-    formContent,
-    formFooter,
-    rightMargin,
-    formFooterContainer
-  } = useStyles();
+const AuthPageForm = forwardRef<HTMLFormElement, Props>(
+  ({ children, title, onPressCTA, ctaText, footer, ...rest }, ref) => {
+    const {
+      form,
+      formContent,
+      formFooter,
+      rightMargin,
+      formFooterContainer
+    } = useStyles();
 
-  const [isSubmitting, setIsSubmitting] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const stopLoading = useCallback(() => {
-    setIsSubmitting(false);
-  }, []);
+    const stopLoading = useCallback(() => {
+      setIsSubmitting(false);
+    }, []);
 
-  const handleSubmit = useCallback(
-    async (e: React.FormEvent<HTMLFormElement>) => {
-      e.preventDefault();
-      setIsSubmitting(true);
-      // Let onPressCTA control when to stop loading
-      await onPressCTA(stopLoading);
-    },
-    [onPressCTA, stopLoading]
-  );
+    const handleSubmit = useCallback(
+      async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        setIsSubmitting(true);
+        // Let onPressCTA control when to stop loading
+        await onPressCTA(stopLoading);
+      },
+      [onPressCTA, stopLoading]
+    );
 
-  return (
-    <AuthPageFormContainer {...rest}>
-      <Typography variant="h4">{title}</Typography>
-      <form className={form} onSubmit={handleSubmit}>
-        <div className={formContent}>{children}</div>
-        <div className={formFooterContainer}>
-          <div className={formFooter}>
-            <Button
-              color="primary"
-              variant="contained"
-              type="submit"
-              disabled={isSubmitting}
-            >
-              {isSubmitting && (
-                <CircularProgress
-                  className={rightMargin}
-                  color="inherit"
-                  size={16}
-                />
-              )}
-              {ctaText}
-            </Button>
-            {footer}
+    return (
+      <AuthPageFormContainer {...rest}>
+        <Typography variant="h4">{title}</Typography>
+        <form ref={ref} className={form} onSubmit={handleSubmit}>
+          <div className={formContent}>{children}</div>
+          <div className={formFooterContainer}>
+            <div className={formFooter}>
+              <Button
+                color="primary"
+                variant="contained"
+                type="submit"
+                disabled={isSubmitting}
+              >
+                {isSubmitting && (
+                  <CircularProgress
+                    className={rightMargin}
+                    color="inherit"
+                    size={16}
+                  />
+                )}
+                {ctaText}
+              </Button>
+              {footer}
+            </div>
           </div>
-        </div>
-      </form>
-    </AuthPageFormContainer>
-  );
-};
+        </form>
+      </AuthPageFormContainer>
+    );
+  }
+);
 
 export default AuthPageForm;

--- a/components/auth/LoginFormContent.tsx
+++ b/components/auth/LoginFormContent.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useRef } from "react";
 
 import { login } from "requests/admin";
 import { useRouter } from "next/router";
@@ -8,8 +8,12 @@ import cookie from "js-cookie";
 
 import ButtonWithLowercaseText from "components/ButtonWithLowercaseText";
 import AuthPageForm from "./AuthPageForm";
-import LoginFormEmailField from "./LoginFormEmailField";
-import LoginFormPasswordField from "./LoginFormPasswordField";
+import LoginFormEmailField, {
+  EMAIL_INPUT_FIELD_NAME
+} from "./LoginFormEmailField";
+import LoginFormPasswordField, {
+  PASSWORD_INPUT_FIELD_NAME
+} from "./LoginFormPasswordField";
 
 import { ContentComponentProps } from "./types";
 
@@ -17,27 +21,16 @@ const LoginFormContent: React.FC<ContentComponentProps> = ({
   navigateToContent
 }) => {
   const router = useRouter();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
+  const formRef = useRef<HTMLFormElement>(null);
   const [error, setError] = useState("");
-
-  const onChangeEmail = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setEmail(e.target.value);
-    },
-    []
-  );
-
-  const onChangePassword = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setPassword(e.target.value);
-    },
-    []
-  );
 
   const onPressCTA = useCallback(
     async (stopLoading: () => void) => {
       try {
+        const data = new FormData(formRef.current ?? undefined);
+        const email = data.get(EMAIL_INPUT_FIELD_NAME) as string;
+        const password = data.get(PASSWORD_INPUT_FIELD_NAME) as string;
+
         /* Not setting expires explicitly - the time of expiry is taken care of by the server when it creates the token.
          * A browser may still store the expired token, however calling checkToken on it would return false.
          * If a user logs in again, the expired token will be re-written with a freshly generated one. */
@@ -54,7 +47,7 @@ const LoginFormContent: React.FC<ContentComponentProps> = ({
         stopLoading();
       }
     },
-    [email, password, router]
+    [router]
   );
 
   const onClickForgotPassword = useCallback(() => {
@@ -63,6 +56,7 @@ const LoginFormContent: React.FC<ContentComponentProps> = ({
 
   return (
     <AuthPageForm
+      ref={formRef}
       title="Sign In"
       ctaText="SIGN IN"
       onPressCTA={onPressCTA}
@@ -76,14 +70,8 @@ const LoginFormContent: React.FC<ContentComponentProps> = ({
         </ButtonWithLowercaseText>
       }
     >
-      <LoginFormEmailField
-        email={email}
-        onChangeEmail={onChangeEmail}
-        hasError={Boolean(error)}
-      />
+      <LoginFormEmailField hasError={Boolean(error)} />
       <LoginFormPasswordField
-        password={password}
-        onChangePassword={onChangePassword}
         hasError={Boolean(error)}
         hasErrorHelperText={error}
       />

--- a/components/auth/LoginFormEmailField.tsx
+++ b/components/auth/LoginFormEmailField.tsx
@@ -6,6 +6,8 @@ import TextField from "@material-ui/core/TextField";
 import InputAdornment from "@material-ui/core/InputAdornment";
 import EmailOutlinedIcon from "@material-ui/icons/EmailOutlined";
 
+export const EMAIL_INPUT_FIELD_NAME = "user_email";
+
 const useStyles = makeStyles({
   verticalMargins: {
     margin: "5vh 0"
@@ -13,15 +15,11 @@ const useStyles = makeStyles({
 });
 
 interface Props {
-  email: string;
-  onChangeEmail: (e: React.ChangeEvent<HTMLInputElement>) => void;
   hasError: boolean;
   hasErrorHelperText?: string;
 }
 
 const LoginFormEmailField: React.FC<Props> = ({
-  email,
-  onChangeEmail,
   hasError,
   hasErrorHelperText = ""
 }) => {
@@ -35,8 +33,7 @@ const LoginFormEmailField: React.FC<Props> = ({
       variant="standard"
       type="email"
       placeholder="email@nonprofit.com"
-      value={email}
-      onChange={onChangeEmail}
+      name={EMAIL_INPUT_FIELD_NAME}
       error={hasError}
       helperText={hasError ? hasErrorHelperText : ""}
       InputProps={{

--- a/components/auth/LoginFormPasswordField.tsx
+++ b/components/auth/LoginFormPasswordField.tsx
@@ -8,16 +8,14 @@ import VisibilityOff from "@material-ui/icons/VisibilityOff";
 
 import LockOutlinedIcon from "@material-ui/icons/LockOutlined";
 
+export const PASSWORD_INPUT_FIELD_NAME = "user_password";
+
 interface Props {
-  password: string;
-  onChangePassword: (e: React.ChangeEvent<HTMLInputElement>) => void;
   hasError: boolean;
   hasErrorHelperText: string;
 }
 
 const LoginFormPasswordField: React.FC<Props> = ({
-  password,
-  onChangePassword,
   hasError,
   hasErrorHelperText
 }) => {
@@ -33,8 +31,7 @@ const LoginFormPasswordField: React.FC<Props> = ({
       fullWidth
       variant="standard"
       placeholder="Enter password"
-      value={password}
-      onChange={onChangePassword}
+      name={PASSWORD_INPUT_FIELD_NAME}
       error={hasError}
       type={showPassword ? "text" : "password"}
       helperText={hasError ? hasErrorHelperText : ""}

--- a/components/auth/RecoverPasswordFormContent.tsx
+++ b/components/auth/RecoverPasswordFormContent.tsx
@@ -1,7 +1,9 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useRef } from "react";
 
 import Typography from "@material-ui/core/Typography";
-import LoginFormEmailField from "./LoginFormEmailField";
+import LoginFormEmailField, {
+  EMAIL_INPUT_FIELD_NAME
+} from "./LoginFormEmailField";
 
 import AuthPageForm from "./AuthPageForm";
 
@@ -21,41 +23,43 @@ const states = {
 const RecoverPasswordFormContent: React.FC<ContentComponentProps> = ({
   navigateToContent
 }) => {
-  const [email, setEmail] = useState("");
+  // TODO: Use this to show an error message below the email input field
   const [hasError] = useState(false);
+  const formRef = useRef<HTMLFormElement>(null);
   const [currentState, setCurrentState] = useState<keyof typeof states>(
     "INITIAL"
-  );
-
-  const onChangeEmail = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setEmail(e.target.value);
-    },
-    []
   );
 
   const onClickGoBack = useCallback(() => {
     navigateToContent("login");
   }, [navigateToContent]);
 
-  const onPressCTA = useCallback(async () => {
-    switch (currentState) {
-      case "INITIAL":
-        // TODO: await some async function that sends password recovery email to the user
-        setCurrentState("FINAL");
-        break;
-      case "FINAL":
-        onClickGoBack();
-        break;
-      default: {
-        const _exhaustiveCheck: never = currentState;
-        return _exhaustiveCheck;
+  const onPressCTA = useCallback(
+    async (stopLoading: () => void) => {
+      switch (currentState) {
+        case "INITIAL": {
+          const data = new FormData(formRef.current ?? undefined);
+          const email = data.get(EMAIL_INPUT_FIELD_NAME) as string;
+          // TODO: await some async function that sends password recovery email to the user
+          stopLoading();
+          setCurrentState("FINAL");
+          break;
+        }
+        case "FINAL":
+          onClickGoBack();
+          break;
+        default: {
+          const _exhaustiveCheck: never = currentState;
+          return _exhaustiveCheck;
+        }
       }
-    }
-  }, [currentState, onClickGoBack]);
+    },
+    [currentState, onClickGoBack]
+  );
 
   return (
     <AuthPageForm
+      ref={formRef}
       title="Recover Password"
       hasBackButton={currentState !== "FINAL"}
       onPressBackButton={onClickGoBack}
@@ -63,8 +67,6 @@ const RecoverPasswordFormContent: React.FC<ContentComponentProps> = ({
       onPressCTA={onPressCTA}
     >
       <LoginFormEmailField
-        email={email}
-        onChangeEmail={onChangeEmail}
         hasError={hasError}
         hasErrorHelperText="Something went wrong, please try later."
       />

--- a/components/auth/RecoverPasswordFormContent.tsx
+++ b/components/auth/RecoverPasswordFormContent.tsx
@@ -38,9 +38,9 @@ const RecoverPasswordFormContent: React.FC<ContentComponentProps> = ({
     async (stopLoading: () => void) => {
       switch (currentState) {
         case "INITIAL": {
-          const data = new FormData(formRef.current ?? undefined);
-          const email = data.get(EMAIL_INPUT_FIELD_NAME) as string;
           // TODO: await some async function that sends password recovery email to the user
+          // const data = new FormData(formRef.current ?? undefined);
+          // const email = data.get(EMAIL_INPUT_FIELD_NAME) as string;
           stopLoading();
           setCurrentState("FINAL");
           break;

--- a/components/auth/types.ts
+++ b/components/auth/types.ts
@@ -1,4 +1,4 @@
-export type Content = "login" | "forgotPassword" | "chooseService";
+export type Content = "login" | "forgotPassword";
 
 export interface ContentComponentProps {
   navigateToContent: (content: Content) => void;


### PR DESCRIPTION
* Cleaning-up some state management code, let's use `FormData` instead of `useState`. This prevents the unnecessary re-rendering of the entire `<form>` element whenever a user types something in the input fields.
* Creating a new `AuthPageContent` component, which prevents the entire auth page from re-rendering when the user transitions from the sign-in component to the forget-password component.