### PR TITLE
Clean-up state management in donation components.

### DIFF
--- a/components/donation/DonationPage.tsx
+++ b/components/donation/DonationPage.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer } from "react";
+import React from "react";
 
 import makeStyles from "@material-ui/core/styles/makeStyles";
 
@@ -8,8 +8,6 @@ import { Nonprofit, DropdownProps } from "utils/types";
 import DonationPageLayout from "./DonationPageLayout";
 import DonationPageFormHeader from "./DonationPageFormHeader";
 import DonationPageFormBody from "./DonationPageFormBody";
-
-import reducer, { initialState, DonationPageStateDispatch } from "./reducer";
 
 const useStyles = makeStyles({
   container: {
@@ -27,21 +25,19 @@ const DonationPage: React.FC<Props & DropdownProps> = ({
   ...dropdownProps
 }) => {
   const { container } = useStyles();
-  const [state, dispatch] = useReducer(reducer, initialState);
 
+  // Setting key will tell React to re-mount the DonationPageFormBody component when the selected Nonprofit in the dropdown changes
   return (
-    <DonationPageStateDispatch.Provider value={dispatch}>
-      <DonationPageLayout {...dropdownProps}>
-        <ContainerWithShadow className={container}>
-          <DonationPageFormHeader headline={nonprofit.headline} />
-          <DonationPageFormBody
-            state={state}
-            description={nonprofit.about}
-            selectedNonprofitId={dropdownProps.selectedValue}
-          />
-        </ContainerWithShadow>
-      </DonationPageLayout>
-    </DonationPageStateDispatch.Provider>
+    <DonationPageLayout {...dropdownProps}>
+      <ContainerWithShadow className={container}>
+        <DonationPageFormHeader headline={nonprofit.headline} />
+        <DonationPageFormBody
+          description={nonprofit.about}
+          selectedNonprofitId={dropdownProps.selectedValue}
+          key={dropdownProps.selectedValue}
+        />
+      </ContainerWithShadow>
+    </DonationPageLayout>
   );
 };
 

--- a/components/donation/DonationPageFormAmountStep.tsx
+++ b/components/donation/DonationPageFormAmountStep.tsx
@@ -53,7 +53,9 @@ const DonationPageFormAmountStep: React.FC<AmountStepProps> = ({
   ]);
 
   const isContinueButtonDisabled = useMemo(
-    () => hasSelectedOther && otherAmount < +MIN_OTHER_AMOUNT,
+    () =>
+      hasSelectedOther &&
+      (otherAmount < +MIN_OTHER_AMOUNT || otherAmount > +MAX_OTHER_AMOUNT),
     [hasSelectedOther, otherAmount]
   );
 
@@ -127,6 +129,7 @@ const DonationPageFormAmountStep: React.FC<AmountStepProps> = ({
         minimumValue={MIN_OTHER_AMOUNT}
         maximumValue={MAX_OTHER_AMOUNT}
         onChange={handleOtherAmountChange}
+        overrideMinMaxLimits="invalid"
       />
     </div>
   );

--- a/components/donation/DonationPageFormBody.tsx
+++ b/components/donation/DonationPageFormBody.tsx
@@ -1,29 +1,12 @@
-import React, { useCallback, useMemo, useContext, useState } from "react";
+import React, { useCallback, useState } from "react";
 import dynamic from "next/dynamic";
 
 import makeStyles from "@material-ui/core/styles/makeStyles";
-import Typography from "@material-ui/core/Typography";
-import CircularProgress from "@material-ui/core/CircularProgress";
 
-import useStripePayment from "./useStripePayment";
-
-import ButtonWithNonprofitColor from "components/ButtonWithNonprofitColor";
-import DonationPageFormNavigation from "./DonationPageFormNavigation";
+import DonationPageFormBodyNonprofitDescription from "./DonationPageFormBodyNonprofitDescription";
+import DonationPageFormBodyStateProvider from "./DonationPageFormBodyStateProvider";
 
 const DonationPageThankYou = dynamic(() => import("./DonationPageThankYou"));
-
-import { createDonation } from "requests/donation";
-
-import {
-  AmountStepProps,
-  ContactStepProps,
-  PaymentStepProps,
-  DonationPageStateDispatch,
-  State,
-  incrementStep,
-  setDonationCompleted
-} from "./reducer";
-import AdminLoginLink from "components/AdminLoginLink";
 
 const white = "white";
 const useStyles = makeStyles({
@@ -33,210 +16,37 @@ const useStyles = makeStyles({
     flexDirection: "column",
     padding: "3.5vh 3vh", // Keep in sync with footerContainer style in DonationPageThankYou
     backgroundColor: white
-  },
-  contentContainer: {
-    flex: 7,
-    marginTop: 8,
-    marginBottom: 8,
-    minHeight: 260
-  },
-  buttonContainer: {
-    display: "flex",
-    flex: 0.75,
-    flexDirection: "column",
-    alignItems: "center",
-    minHeight: 72
-  },
-  textContainer: {
-    flex: 1.5
-  },
-  rightMargin: {
-    marginRight: 8
   }
 });
 
-const options = {
-  ssr: false
-};
-
-const STEPS = [
-  {
-    title: "Donation Amount" as const,
-    component: dynamic<AmountStepProps>(
-      () => import("./DonationPageFormAmountStep"),
-      options
-    )
-  },
-  {
-    title: "Contact" as const,
-    component: dynamic<ContactStepProps>(
-      () => import("./DonationPageFormContactStep"),
-      options
-    )
-  },
-  {
-    title: "Payment" as const,
-    component: dynamic<PaymentStepProps>(
-      () => import("./DonationPageFormPaymentStep"),
-      options
-    )
-  }
-];
-
 interface Props {
   description: string;
-  state: State;
   selectedNonprofitId: string;
 }
 
 const DonationPageFormBody: React.FC<Props> = ({
   description,
-  selectedNonprofitId,
-  state: {
-    curStepIndex,
-    maxCurStepIndex,
-    isContinueButtonDisabled,
-    contactStep,
-    amountStep,
-    paymentStep,
-    donationCompleted
-  }
+  selectedNonprofitId
 }) => {
-  const {
-    container,
-    contentContainer,
-    buttonContainer,
-    textContainer,
-    rightMargin
-  } = useStyles();
-  const dispatch = useContext(DonationPageStateDispatch);
+  const { container } = useStyles();
+  const [hasDonationCompleted, setHasDonationCompleted] = useState(false);
 
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const donationCompletedCallback = useCallback(() => {
+    setHasDonationCompleted(true);
+  }, []);
 
-  const { isReady, processPayment } = useStripePayment();
-
-  const isLastStep = useMemo(() => curStepIndex === STEPS.length - 1, [
-    curStepIndex
-  ]);
-
-  const amount = useMemo(
-    () => amountStep.radioButtonAmount ?? amountStep.otherAmount,
-    [amountStep.otherAmount, amountStep.radioButtonAmount]
-  );
-  const ctaText = useMemo(
-    () => (isLastStep ? `Donate $${amount.toFixed(2)}` : "Continue"),
-    [isLastStep, amount]
-  );
-
-  const handleSubmit = useCallback(
-    async (e: React.FormEvent<HTMLFormElement>) => {
-      e.preventDefault();
-      if (!e.currentTarget.reportValidity()) return;
-
-      if (isLastStep) {
-        try {
-          setIsSubmitting(true);
-          // TODO: Check if we should use paymentStep.name instead
-          const name = `${contactStep.firstName} ${contactStep.lastName}`;
-          const email = contactStep.email;
-          await processPayment(
-            name,
-            contactStep.email,
-            paymentStep.zipcode,
-            amount
-          );
-          // TODO: What should we do if Stripe has processed the payment correctly, but our createDonation API call errored?
-          await createDonation({
-            name,
-            email,
-            amount,
-            nonprofitId: selectedNonprofitId
-          });
-
-          dispatch && dispatch(setDonationCompleted(true));
-        } catch (err) {
-          // TODO: Not sure how else to handle and display the error
-          alert(err.message);
-        } finally {
-          setIsSubmitting(false);
-        }
-      } else {
-        dispatch && dispatch(incrementStep());
-      }
-    },
-    [
-      dispatch,
-      amount,
-      contactStep.email,
-      contactStep.firstName,
-      contactStep.lastName,
-      paymentStep.zipcode,
-      processPayment,
-      isLastStep,
-      selectedNonprofitId
-    ]
-  );
-
-  const step = STEPS[curStepIndex];
-  const componentJSX = useMemo(() => {
-    let Component;
-    switch (step.title) {
-      case "Donation Amount":
-        Component = step.component;
-        return <Component {...amountStep} />;
-
-      case "Contact":
-        Component = step.component;
-        return <Component {...contactStep} />;
-
-      case "Payment":
-        Component = step.component;
-        return <Component {...paymentStep} />;
-
-      default: {
-        const _exhaustiveCheck: never = step;
-        return _exhaustiveCheck;
-      }
-    }
-  }, [step, contactStep, amountStep, paymentStep]);
-
-  const nonprofitDescriptionJSX = (
-    <div className={textContainer}>
-      <Typography>{description}</Typography>
-    </div>
-  );
-
-  return donationCompleted ? (
+  return (
     <div className={container}>
-      {nonprofitDescriptionJSX}
-      <DonationPageThankYou />
+      <DonationPageFormBodyNonprofitDescription description={description} />
+      {hasDonationCompleted ? (
+        <DonationPageThankYou />
+      ) : (
+        <DonationPageFormBodyStateProvider
+          donationCompletedCallback={donationCompletedCallback}
+          selectedNonprofitId={selectedNonprofitId}
+        />
+      )}
     </div>
-  ) : (
-    <form className={container} onSubmit={handleSubmit}>
-      {nonprofitDescriptionJSX}
-      <DonationPageFormNavigation
-        curStepIndex={curStepIndex}
-        maxCurStepIndex={maxCurStepIndex}
-        stepTitles={STEPS.map(_ => _.title)}
-      />
-      <div className={contentContainer}>{componentJSX}</div>
-      <div className={buttonContainer}>
-        <ButtonWithNonprofitColor
-          disabled={isContinueButtonDisabled || !isReady || isSubmitting}
-          type="submit"
-        >
-          {isSubmitting && (
-            <CircularProgress
-              className={rightMargin}
-              color="inherit"
-              size={16}
-            />
-          )}
-          {ctaText}
-        </ButtonWithNonprofitColor>
-        <AdminLoginLink />
-      </div>
-    </form>
   );
 };
 

--- a/components/donation/DonationPageFormBodyNonprofitDescription.tsx
+++ b/components/donation/DonationPageFormBodyNonprofitDescription.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import makeStyles from "@material-ui/core/styles/makeStyles";
+import Typography from "@material-ui/core/Typography";
+
+const useStyles = makeStyles({
+  textContainer: {
+    flex: 0.2
+  }
+});
+
+interface Props {
+  description: string;
+}
+
+const DonationPageFormBodyNonprofitDescription: React.FC<Props> = ({
+  description
+}) => {
+  const { textContainer } = useStyles();
+
+  return (
+    <div className={textContainer}>
+      <Typography>{description}</Typography>
+    </div>
+  );
+};
+
+export default DonationPageFormBodyNonprofitDescription;

--- a/components/donation/DonationPageFormBodyStateProvider.tsx
+++ b/components/donation/DonationPageFormBodyStateProvider.tsx
@@ -1,0 +1,221 @@
+import React, { useCallback, useMemo, useState, useReducer } from "react";
+import dynamic from "next/dynamic";
+
+import makeStyles from "@material-ui/core/styles/makeStyles";
+import CircularProgress from "@material-ui/core/CircularProgress";
+
+import useStripePayment from "./useStripePayment";
+
+import ButtonWithNonprofitColor from "components/ButtonWithNonprofitColor";
+import DonationPageFormNavigation from "./DonationPageFormNavigation";
+
+import { createDonation } from "requests/donation";
+
+import reducer, {
+  AmountStepProps,
+  ContactStepProps,
+  PaymentStepProps,
+  initialState,
+  DonationPageStateDispatch,
+  incrementStep
+} from "./reducer";
+import AdminLoginLink from "components/AdminLoginLink";
+
+const useStyles = makeStyles({
+  container: {
+    display: "flex",
+    flex: 0.8,
+    flexDirection: "column"
+  },
+  contentContainer: {
+    flex: 7,
+    marginTop: 8,
+    marginBottom: 8,
+    minHeight: 260
+  },
+  buttonContainer: {
+    display: "flex",
+    flex: 0.75,
+    flexDirection: "column",
+    alignItems: "center",
+    minHeight: 72
+  },
+  rightMargin: {
+    marginRight: 8
+  }
+});
+
+const options = {
+  ssr: false
+};
+
+const STEPS = [
+  {
+    title: "Donation Amount" as const,
+    component: dynamic<AmountStepProps>(
+      () => import("./DonationPageFormAmountStep"),
+      options
+    )
+  },
+  {
+    title: "Contact" as const,
+    component: dynamic<ContactStepProps>(
+      () => import("./DonationPageFormContactStep"),
+      options
+    )
+  },
+  {
+    title: "Payment" as const,
+    component: dynamic<PaymentStepProps>(
+      () => import("./DonationPageFormPaymentStep"),
+      options
+    )
+  }
+];
+
+interface Props {
+  donationCompletedCallback: () => void;
+  selectedNonprofitId: string;
+}
+
+const DonationPageFormBodyStateProvider: React.FC<Props> = ({
+  donationCompletedCallback,
+  selectedNonprofitId
+}) => {
+  const {
+    container,
+    contentContainer,
+    buttonContainer,
+    rightMargin
+  } = useStyles();
+  const [
+    {
+      curStepIndex,
+      isContinueButtonDisabled,
+      contactStep,
+      amountStep,
+      paymentStep
+    },
+    dispatch
+  ] = useReducer(reducer, initialState);
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const { isReady, processPayment } = useStripePayment();
+
+  const isLastStep = useMemo(() => curStepIndex === STEPS.length - 1, [
+    curStepIndex
+  ]);
+
+  const amount = useMemo(
+    () => amountStep.radioButtonAmount ?? amountStep.otherAmount,
+    [amountStep.otherAmount, amountStep.radioButtonAmount]
+  );
+  const ctaText = useMemo(
+    () => (isLastStep ? `Donate $${amount.toFixed(2)}` : "Continue"),
+    [isLastStep, amount]
+  );
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (!e.currentTarget.reportValidity()) return;
+
+      if (isLastStep) {
+        try {
+          setIsSubmitting(true);
+          // TODO: Check if we should use paymentStep.name instead
+          const name = `${contactStep.firstName} ${contactStep.lastName}`;
+          const email = contactStep.email;
+          await processPayment(
+            name,
+            contactStep.email,
+            paymentStep.zipcode,
+            amount
+          );
+          // TODO: What should we do if Stripe has processed the payment correctly, but our createDonation API call errored?
+          await createDonation({
+            name,
+            email,
+            amount,
+            nonprofitId: selectedNonprofitId
+          });
+
+          donationCompletedCallback();
+          // Don't call setIsSubmitting(false) after this -- donationCompletedCallback() will unmount this component
+        } catch (err) {
+          // TODO: Not sure how else to handle and display the error
+          setIsSubmitting(false);
+          alert(err.message);
+        }
+      } else {
+        dispatch(incrementStep());
+      }
+    },
+    [
+      dispatch,
+      amount,
+      contactStep.email,
+      contactStep.firstName,
+      contactStep.lastName,
+      paymentStep.zipcode,
+      processPayment,
+      isLastStep,
+      selectedNonprofitId,
+      donationCompletedCallback
+    ]
+  );
+
+  const step = STEPS[curStepIndex];
+  const componentJSX = useMemo(() => {
+    let Component;
+    switch (step.title) {
+      case "Donation Amount":
+        Component = step.component;
+        return <Component {...amountStep} />;
+
+      case "Contact":
+        Component = step.component;
+        return <Component {...contactStep} />;
+
+      case "Payment":
+        Component = step.component;
+        return <Component {...paymentStep} />;
+
+      default: {
+        const _exhaustiveCheck: never = step;
+        return _exhaustiveCheck;
+      }
+    }
+  }, [step, contactStep, amountStep, paymentStep]);
+
+  return (
+    <DonationPageStateDispatch.Provider value={dispatch}>
+      <form className={container} onSubmit={handleSubmit}>
+        <DonationPageFormNavigation
+          curStepIndex={curStepIndex}
+          stepTitles={STEPS.map(_ => _.title)}
+        />
+        <div className={contentContainer}>{componentJSX}</div>
+        <div className={buttonContainer}>
+          <ButtonWithNonprofitColor
+            disabled={isContinueButtonDisabled || !isReady || isSubmitting}
+            type="submit"
+          >
+            {isSubmitting && (
+              <CircularProgress
+                className={rightMargin}
+                color="inherit"
+                size={16}
+              />
+            )}
+            {ctaText}
+          </ButtonWithNonprofitColor>
+          <AdminLoginLink />
+        </div>
+      </form>
+    </DonationPageStateDispatch.Provider>
+  );
+};
+
+export default DonationPageFormBodyStateProvider;

--- a/components/donation/DonationPageFormNavigation.tsx
+++ b/components/donation/DonationPageFormNavigation.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useState, useEffect, useContext } from "react";
 
 import makeStyles from "@material-ui/core/styles/makeStyles";
 import ArrowForwardIosIcon from "@material-ui/icons/ArrowForwardIos";
@@ -33,19 +33,22 @@ const useStyles = makeStyles({
 
 interface Props {
   curStepIndex: number;
-  maxCurStepIndex: number;
   stepTitles: string[];
 }
 
 const DonationPageFormNavigation: React.FC<Props> = ({
   curStepIndex,
-  maxCurStepIndex,
   stepTitles
 }) => {
   const { container, icon, positiveMargin } = useStyles();
-  const arr: React.ReactNode[] = [];
   const dispatch = useContext(DonationPageStateDispatch);
+  const [maxCurStepIndex, setMaxCurStepIndex] = useState(-1);
 
+  useEffect(() => {
+    setMaxCurStepIndex(s => Math.max(s, curStepIndex));
+  }, [curStepIndex]);
+
+  const arr: React.ReactNode[] = [];
   stepTitles.forEach((title, index) => {
     arr.push(
       <ButtonWithLowercaseText

--- a/components/donation/DonationPageHeaderSelect.tsx
+++ b/components/donation/DonationPageHeaderSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useContext, useEffect } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 
 import clsx from "clsx";
 
@@ -15,12 +15,6 @@ import MenuItem from "@material-ui/core/MenuItem";
 import { DropdownProps } from "utils/types";
 
 import urls from "config";
-
-import {
-  DonationPageStateDispatch,
-  resetState,
-  setIsContinueButtonDisabled
-} from "./reducer";
 
 const useStyles = makeStyles(({ palette, typography }: Theme) =>
   createStyles({
@@ -52,17 +46,14 @@ const DonationPageHeaderSelect: React.FC<DropdownProps> = ({
   const router = useRouter();
   const [value, setValue] = useState(selectedValue);
   const [disabled, setDisabled] = useState(false);
-  const dispatch = useContext(DonationPageStateDispatch);
 
   const routeChangeStart = useCallback(() => {
-    dispatch && dispatch(setIsContinueButtonDisabled(true));
     setDisabled(true);
-  }, [dispatch]);
+  }, []);
 
   const routeChangeComplete = useCallback(() => {
-    dispatch && dispatch(resetState()); // Takes care of setIsContinueButtonDisabled(false)
     setDisabled(false);
-  }, [dispatch]);
+  }, []);
 
   const onChange = useCallback(
     (

--- a/components/donation/reducer.ts
+++ b/components/donation/reducer.ts
@@ -18,14 +18,12 @@ export interface PaymentStepProps {
   zipcode: string;
 }
 
-export type State = {
+type State = {
   curStepIndex: number;
-  maxCurStepIndex: number;
   isContinueButtonDisabled: boolean;
   contactStep: ContactStepProps;
   amountStep: AmountStepProps;
   paymentStep: PaymentStepProps;
-  donationCompleted: boolean;
 };
 
 export const AMOUNTS = [25, 50, 100, 250, 500];
@@ -35,7 +33,6 @@ export const MAX_OTHER_AMOUNT = "2000";
 
 export const initialState: State = {
   curStepIndex: 0,
-  maxCurStepIndex: 0,
   isContinueButtonDisabled: false,
   contactStep: {
     firstName: "",
@@ -49,30 +46,21 @@ export const initialState: State = {
   paymentStep: {
     nameOnCard: "",
     zipcode: ""
-  },
-  donationCompleted: false
+  }
 };
 
 const name = "donationPageSlice";
-
-const setMaxCurStepIndex = (state: State) => {
-  state.maxCurStepIndex = Math.max(state.maxCurStepIndex, state.curStepIndex);
-};
-
 const { actions, reducer } = createSlice({
   name,
   initialState,
   reducers: {
-    resetState: () => initialState,
     incrementStep(state) {
       state.curStepIndex++;
       // A safe assumption to make, may not always hold true. Also, maybe the form UI takes time to load, in that case it won't be prudent to enable the continue button:
       state.isContinueButtonDisabled = true;
-      setMaxCurStepIndex(state);
     },
     setStep(state, { payload }: PayloadAction<number>) {
       state.curStepIndex = payload;
-      setMaxCurStepIndex(state);
     },
     setIsContinueButtonDisabled(state, { payload }: PayloadAction<boolean>) {
       state.isContinueButtonDisabled = payload;
@@ -98,9 +86,6 @@ const { actions, reducer } = createSlice({
     setZipcode({ paymentStep }, { payload }: PayloadAction<string>) {
       // From https://github.com/medipass/react-credit-card-input/blob/master/src/utils/formatter.js#L135
       paymentStep.zipcode = (payload.match(/\d+/g) || []).join("");
-    },
-    setDonationCompleted(state, { payload }: PayloadAction<boolean>) {
-      state.donationCompleted = payload;
     }
   }
 });
@@ -110,7 +95,6 @@ export const DonationPageStateDispatch = createContext<Dispatch<
 > | null>(null);
 
 export const {
-  resetState,
   incrementStep,
   setStep,
   setIsContinueButtonDisabled,
@@ -118,8 +102,8 @@ export const {
   setOtherAmount,
   setContactStepField,
   setNameOnCard,
-  setZipcode,
-  setDonationCompleted
+  setZipcode
+  // setDonationCompleted
 } = actions;
 
 export default reducer;

--- a/components/donation/reducer.ts
+++ b/components/donation/reducer.ts
@@ -103,7 +103,6 @@ export const {
   setContactStepField,
   setNameOnCard,
   setZipcode
-  // setDonationCompleted
 } = actions;
 
 export default reducer;


### PR DESCRIPTION
* By using state from `useReducer` in the donation page's root component, we were triggering unnecessary re-renders of the entire page whenever a user interacted with the donation form.
* The reducer has been simplified -- some fields (and corresponding actions) have been removed since they can be implemented using a local `useState`.
* Most of the state management code has been moved to a new component - `DonationPageFormBodyStateProvider`, to avoid the unnecessary re-renders. **However, I think this component is still too large. I will be opening another PR to break-up this component and re-name some other components so that the `donation/` folder is better organized.**  
* This PR also fixes a console warning related to the usage of `CurrencyTextField` component.
