### PR TITLE
Sync secrets using bitwarden item ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "secrets": "yarn run secrets:logout && yarn run secrets:login 'yarn run secrets:sync'",
     "secrets:logout": "(bw logout || true)",
     "secrets:login": "cross-env-shell BW_SESSION=`bw login product@bitsofgood.org --raw`",
-    "secrets:sync": "bw sync && bw get item gen-soln/.env | fx .notes > '.env'"
+    "secrets:sync": "bw sync && bw get item 568a4d59-6d37-4a71-8da5-ac23015d7770 | fx .notes > '.env'"
   },
   "dependencies": {
     "@material-ui/core": "^4.9.2",


### PR DESCRIPTION
Also switches to using the development `.env` file instead of the production one