### PR TITLE
Update ci-cd.yml

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,5 +1,13 @@
 name: CI/CD
-on: [pull_request, push]
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Only run `ci-cd.yml` on push and pull events to `master` and `develop`, instead of all branches.