### PR TITLE
Fix migration script for windows users

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "dev:db:migrate": "NODE_ENV=development yarn ts-node -O '{\"module\": \"commonjs\"}' -r module-alias/register server/migration.ts",
+    "dev:db:migrate": "cross-env NODE_ENV=development yarn ts-node -O {\\\"module\\\":\\\"commonjs\\\"} -r module-alias/register server/migration.ts",
     "start": "next start",
     "lint": "yarn lint:tsc ; yarn lint:eslint",
     "lint:tsc": "tsc -p tsconfig.json --noEmit",


### PR DESCRIPTION
Use `cross-env` to handle setting `NODE_ENV`

Tested in cmd:
![image](https://user-images.githubusercontent.com/8410924/92330133-9a8e2e00-f03a-11ea-9d44-d5bca6b4c205.png)

And wsl:
![image](https://user-images.githubusercontent.com/8410924/92330137-a974e080-f03a-11ea-883c-346aa1c2701b.png)
