### PR TITLE
Updated README for Windows and packages.json secrets scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ From https://github.com/GTBitsOfGood/nextjs-starter-typescript
 - Follow the instructions [here](https://www.notion.so/gtbitsofgood/Getting-Started-56106473076a47eaa8c863741becbf34) to install Git, Node.js (v12.X LTS at least) and the MongoDB Community Server.
 - Install the Node.js package manager [yarn](https://classic.yarnpkg.com/en/docs/install/).
 - Navigate to this project in the terminal and run `yarn install`.
-- Run `yarn secrets` to sync project secrets from Bitwarden and save them to `.env.*` files locally. Contact a leadership member for the Bitwarden password.
+- Run `yarn secrets` to sync project secrets from Bitwarden and save them to `.env.*` files locally. For Windows users, you have to run `yarn secrets:login` and then `yarn secrets:sync` instead of `yarn secrets`. Contact a leadership member for the Bitwarden password. 
 - Start your local MongoDB server by running `mongod` (this command will work if you created aliases as recommended in [this](https://zellwk.com/blog/install-mongodb/) article).
 - Next, perform migrations on your local database: `yarn dev:db:migrate up`. You should run this command whenever a new migration is added to the codebase; you can run `yarn dev:db:migrate status` to check if your local database is up to date.
 - Run the dev version of this project by entering `yarn dev`.

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "lint": "yarn lint:tsc ; yarn lint:eslint",
     "lint:tsc": "tsc -p tsconfig.json --noEmit",
     "lint:eslint": "eslint '**/*.{tsx,ts,js,jsx}' --fix",
-    "secrets": "yarn secrets:logout && yarn secrets:login 'yarn secrets:sync'",
+    "secrets": "npm run secrets:logout && cross-env-shell BW_SESSION=`bw login product@bitsofgood.org --raw` \"npm run secrets:sync\"",
     "secrets:logout": "(bw logout || true)",
-    "secrets:login": "cross-env-shell BW_SESSION=`bw login product@bitsofgood.org --raw`",
+    "secrets:login": "bw login product@bitsofgood.org",
     "secrets:sync": "bw sync && bw get item gen-soln/.env.local | fx .notes > '.env.local' && bw get item gen-soln/.env.development.local | fx .notes > '.env.development.local'"
   },
   "dependencies": {


### PR DESCRIPTION
README now tells windows users to use yarn secrets:login and yarn secrets:sync in order to fully sync. Also, secrets scripts are updated to newer ones.