### PR TITLE
Add caching action to CI/CD workflow.

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -17,6 +17,16 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Lint files and run type-checks


### PR DESCRIPTION
* Use GitHub cache action to cache yarn dependencies.
* This should help speed up our ci-cd workflow, which currently takes around 50 seconds just to install dependencies.
* Code from: https://github.com/actions/cache/blob/main/examples.md#node---yarn