### PR TITLE
Add large event card component

### DIFF
--- a/components/events/EventCardLarge.tsx
+++ b/components/events/EventCardLarge.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import clsx from "clsx";
+
+import makeStyles from "@material-ui/core/styles/makeStyles";
+import Typography from "@material-ui/core/Typography";
+
+const useStyles = makeStyles({
+  card: {
+    width: 248,
+    height: 267,
+    borderRadius: 10,
+    overflow: "hidden",
+    backgroundColor: "#FFFFFF",
+    /* 1px borders don't play nice on Chrome, so we use an equivalent
+     * box-shadow and wrap the div in another div */
+    boxShadow: "0 0 0 1px #F0F0F0"
+  },
+  cardContainer: {
+    width: 250,
+    height: 269,
+    padding: 1
+  },
+  image: {
+    display: "block",
+    height: 128,
+    width: "inherit",
+    objectFit: "cover"
+  },
+  content: {
+    padding: "16px 24px"
+  },
+  header: {
+    color: "#333333",
+    fontFamily: "Visby CF, sans-serif",
+    fontSize: 16,
+    fontWeight: 800,
+    lineHeight: "130%",
+    marginBottom: 6,
+    /* line-clamp isn't supported yet, so the next four rules handle it for us */
+    display: "-webkit-box",
+    WebkitBoxOrient: "vertical",
+    WebkitLineClamp: 2,
+    overflow: "hidden"
+  },
+  body: {
+    color: "#666666",
+    fontFamily: "Open Sans, sans-serif",
+    fontSize: 16,
+    lineHeight: "150%",
+    marginBottom: 6
+  },
+  meta: {
+    color: "#FD8033",
+    fontFamily: "Visby CF, sans-serif",
+    fontSize: 16,
+    fontWeight: 800,
+    lineHeight: "130%",
+    marginBottom: 6
+  },
+  /* Only works for truncating a single line */
+  truncate: {
+    textOverflow: "ellipsis",
+    overflow: "hidden",
+    whiteSpace: "nowrap"
+  }
+});
+
+interface Props {
+  /* Used for event title */
+  headerText: string;
+  /* Used for nonprofit name */
+  bodyText: string;
+  /* Used for time */
+  metaText: string;
+  imagePath: string;
+}
+
+const EventCardLarge: React.FC<Props> = ({
+  headerText,
+  bodyText,
+  metaText,
+  imagePath
+}) => {
+  const {
+    card,
+    cardContainer,
+    content,
+    image,
+    meta,
+    body,
+    header,
+    truncate
+  } = useStyles();
+
+  return (
+    <div className={cardContainer}>
+      <div className={card}>
+        <img src={imagePath} className={image} alt={`${header} event`} />
+        <div className={content}>
+          <Typography className={clsx(meta, truncate)}>{metaText}</Typography>
+          <Typography className={header}>{headerText}</Typography>
+          <Typography className={clsx(body, truncate)}>{bodyText}</Typography>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EventCardLarge;

--- a/components/events/EventCardLarge.tsx
+++ b/components/events/EventCardLarge.tsx
@@ -95,7 +95,7 @@ const EventCardLarge: React.FC<Props> = ({
   return (
     <div className={cardContainer}>
       <div className={card}>
-        <img src={imagePath} className={image} alt={`${header} event`} />
+        <img src={imagePath} className={image} alt={`${headerText}`} />
         <div className={content}>
           <Typography className={clsx(meta, truncate)}>{metaText}</Typography>
           <Typography className={header}>{headerText}</Typography>


### PR DESCRIPTION
#97 
This adds the `EventCardLarge` component which we can use to render an event listing with an image, header text, meta text, and body text. It handles text wrapping properly, and has a fixed height and width.

![localhost_3000_donate_64357724](https://user-images.githubusercontent.com/8410924/92553587-44cfa680-f231-11ea-8039-4cf1f9363116.png)

> Why did you add `card` and `cardContainer`? What's with this `box-shadow`? Why not use `border`?

The 1px border was pushing content over 2 pixels leaving an ugly gap between the image and the border (I think it has something to do with subpixels or something). To handle it, I just added a `box-shadow` on the div and wrapped it in another div with 1px padding.

Notes:
- Width is fixed at 250px, this could be parameterized in the future
- We still need to add Visby CF font to be Figma-compliant


