### PR TITLE
Ticket 79 - Renamed all occurances of createDonation api to logDonation

### DIFF
--- a/components/donation/form/DonationPageForm.tsx
+++ b/components/donation/form/DonationPageForm.tsx
@@ -15,7 +15,7 @@ import useStripePayment from "./useStripePayment";
 import DonationPageFormNavigation from "./DonationPageFormNavigation";
 import DonationPageFormButton from "./DonationPageFormButton";
 
-import { createDonation } from "requests/donation";
+import { logDonation } from "requests/donation";
 
 import reducer, {
   AmountStepProps,
@@ -128,8 +128,8 @@ const DonationPageForm: React.FC<Props> = ({
           return;
         }
         donationCompletedCallback(); // Don't call setIsSubmitting(false) after this -- donationCompletedCallback() will unmount this component
-        // TODO: What should we do if Stripe has processed the payment correctly, but our createDonation API call errored?
-        void createDonation({
+        // TODO: What should we do if Stripe has processed the payment correctly, but our logDonation API call errored?
+        void logDonation({
           name,
           email,
           amount,

--- a/config.ts
+++ b/config.ts
@@ -26,7 +26,7 @@ export default {
   apis: {
     login: "/api/login",
     checkToken: "/api/checkToken",
-    createDonation: "/api/createDonation",
+    logDonation: "/api/logDonation",
     paymentIntents: "/api/paymentIntents",
     // Remove this endpoint when we no longer need to redirect from index.ts
     getDefaultNonprofitId: "/api/getDefaultNonprofitId"

--- a/pages/api/logDonation.ts
+++ b/pages/api/logDonation.ts
@@ -1,15 +1,15 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { createDonation } from "server/actions/donation";
+import { logDonation } from "server/actions/donation";
 import { handleRequestWithPayloadResponse } from "utils/util";
 
-// @route   POST api/createDonation
+// @route   POST api/logDonation
 // @desc    Logs a Donation in our DB; doesn't process the payment nor interacts with Stripe
 // @access  Public
 export default async (
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> =>
-  handleRequestWithPayloadResponse(req, res, createDonation, [
+  handleRequestWithPayloadResponse(req, res, logDonation, [
     "name",
     "email",
     "amount",

--- a/requests/donation.ts
+++ b/requests/donation.ts
@@ -11,13 +11,13 @@ export const createPaymentIntent = async (amount: number): Promise<string> =>
     body: JSON.stringify({ amount })
   });
 
-export const createDonation = async ({
+export const logDonation = async ({
   name,
   email,
   amount,
   nonprofitId
 }: Omit<Donation, "timestamp">): Promise<boolean> =>
-  fetchRequestWithPayloadResponse<boolean>(urls.apis.createDonation, {
+  fetchRequestWithPayloadResponse<boolean>(urls.apis.logDonation, {
     method: "post",
     headers: {
       "Content-Type": "application/json"

--- a/server/actions/donation.ts
+++ b/server/actions/donation.ts
@@ -12,7 +12,7 @@ const stripe = new Stripe(config.stripeSecret!, {
   apiVersion: "2020-03-02"
 });
 
-export async function createDonation({
+export async function logDonation({
   name,
   email,
   amount,


### PR DESCRIPTION
Changed the API Endpoint createDonation to logDonation. This was done by finding all occurrences of "createDonation" and changing them to "logDonation". The file under pages/api was also renamed from createDonation.ts to logDonation.ts . Test of endpoint was done before and after change using stripe's credit card that "does not require authentication". Donation was logged under database - test, collection - donations. 