### PR TITLE
Creates EventsPageLayout component

### DIFF
--- a/components/events/EventsPageLayout.tsx
+++ b/components/events/EventsPageLayout.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { createStyles, makeStyles } from "@material-ui/core/styles";
+import FullPageLayout from "components/FullPageLayout";
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    container: {
+      display: "flex"
+    },
+    sidebar: {
+      flex: 1,
+      display: "flex",
+      height: "100vh",
+      overflowY: "scroll",
+      "&::-webkit-scrollbar": {
+        display: "none"
+      }
+    },
+    content: {
+      flex: 5,
+      display: "flex",
+      height: "100vh",
+      overflowY: "scroll",
+      "&::-webkit-scrollbar": {
+        display: "none"
+      }
+    }
+  })
+);
+
+interface Props {
+  sidebarComponent: React.ReactNode;
+}
+
+const EventsPageLayout: React.FC<Props> = ({ sidebarComponent, children }) => {
+  const { container, sidebar, content } = useStyles();
+
+  return (
+    <FullPageLayout className={container}>
+      <div className={sidebar}>{sidebarComponent}</div>
+      <div className={content}>{children}</div>
+    </FullPageLayout>
+  );
+};
+
+export default EventsPageLayout;


### PR DESCRIPTION
Here is an image of the layout rendered on the `/events` page with scrollbars showing. I used this to verify that each container was independently scrollable.
![event_page](https://user-images.githubusercontent.com/45107667/92680855-f6d2a580-f2f9-11ea-8471-bd2ef5a83197.png)

The current version is below and has the scrollbars hidden, but the divs are still scrollable (I used the above to test since it's hard to tell when the divs are just a block of the same color).
![hidden_scrollbar](https://user-images.githubusercontent.com/45107667/92680864-00f4a400-f2fa-11ea-9f0e-2300f97acfc8.png)
