### PR TITLE
Use 'String' type for non-profit ref in Event model

### DIFF
--- a/server/models/event.js
+++ b/server/models/event.js
@@ -20,7 +20,7 @@ const eventSchema = new Schema({
     required: true
   },
   nonprofitId: {
-    type: Schema.ObjectId,
+    type: String,
     ref: "Nonprofit",
     required: true
   },


### PR DESCRIPTION
Seems we had to use `String` type since `Nonproft` `_id`s are of type `String`