### PR TITLE
Check if nonprofits exist in DB before returning default ID

### DIFF
--- a/server/actions/nonprofit.ts
+++ b/server/actions/nonprofit.ts
@@ -67,5 +67,9 @@ export async function getDefaultNonprofitId(): Promise<string> {
     .sort({ name: 1 })
     .limit(1)) as Array<Pick<NonprofitType, "_id">>;
 
+  if (!result.length) {
+    throw new Error(errors.nonprofit.NO_DATA);
+  }
+
   return result[0]._id;
 }

--- a/utils/errors.ts
+++ b/utils/errors.ts
@@ -8,6 +8,7 @@ export default {
   nonprofit: {
     INVALID_ID:
       "A nonprofit with the provided ID does not exist in our database.",
-    DONATION_LOG_FAILURE: "Unable to log donation for the nonprofit."
+    DONATION_LOG_FAILURE: "Unable to log donation for the nonprofit.",
+    NO_DATA: "The database does not contain any nonprofits."
   }
 };


### PR DESCRIPTION
Making this change since a dev on the Core team ran into an error when running the app without running the migration script. Now, the error message will tell devs that no nonprofits exist in their DB.