### PR TITLE
[DMS] Adds migrations script for test connected stripe account

### DIFF
--- a/server/migrations/20200915011144-migrate-nonprofits-update-redcross-stripe-account.ts
+++ b/server/migrations/20200915011144-migrate-nonprofits-update-redcross-stripe-account.ts
@@ -1,0 +1,17 @@
+import { Db } from "mongodb";
+import { MigrationFunction } from "migrate-mongo";
+
+const stripeTestNonprofit = "American Red Cross";
+const stripeAccount = "acct_1HRQtBDVsYlAZnQ1";
+
+export const up: MigrationFunction = async (db: Db) => {
+  await db
+    .collection("nonprofits")
+    .updateOne({ name: stripeTestNonprofit }, { $set: { stripeAccount } });
+};
+
+export const down: MigrationFunction = async (db: Db) => {
+  await db
+    .collection("nonprofits")
+    .updateOne({ name: stripeTestNonprofit }, { $set: { stripeAccount: "" } });
+};


### PR DESCRIPTION
- Creates a migration script to update local MongoDB tables with a connected Stripe account (created with @ML-Chen helper functions) for testing purposes. This is a test account so account number is not sensitive information.