### PR TITLE
Email text change and db field refactor

### DIFF
--- a/components/auth/form/RecoverPasswordFormContent.tsx
+++ b/components/auth/form/RecoverPasswordFormContent.tsx
@@ -16,7 +16,7 @@ const states = {
     ctaText: "Get Password"
   },
   FINAL: {
-    caption: "A new password has been sent to this email.",
+    caption: "We have emailed a password recovery link to your email.",
     ctaText: "Back to Sign In"
   }
 };

--- a/config.ts
+++ b/config.ts
@@ -1,13 +1,15 @@
 const isDevEnv = process.env.NODE_ENV === "development";
 
 export default {
-  dbName: isDevEnv ? process.env.DEV_DB_NAME : process.env.PROD_DB_NAME,
-  dbUrl: isDevEnv ? process.env.DEV_DB_URL : process.env.PROD_DB_URL,
-  dbOptions: {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-    useFindAndModify: false,
-    useCreateIndex: true
+  db: {
+    name: isDevEnv ? process.env.DEV_DB_NAME : process.env.PROD_DB_NAME,
+    url: isDevEnv ? process.env.DEV_DB_URL : process.env.PROD_DB_URL,
+    options: {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+      useFindAndModify: false,
+      useCreateIndex: true
+    }
   },
   stripe: {
     publishable_key: isDevEnv

--- a/server/index.js
+++ b/server/index.js
@@ -6,9 +6,9 @@ const MongoConnect = async () => {
   if (mongoose.connections[0].readyState) return;
 
   await mongoose
-    .connect(config.dbUrl, {
-      ...config.dbOptions,
-      dbName: config.dbName
+    .connect(config.db.url, {
+      ...config.db.options,
+      dbName: config.db.name
     })
     .catch(error => {
       console.error("Database connection failed. 👇🏼");

--- a/server/migration.ts
+++ b/server/migration.ts
@@ -22,9 +22,9 @@ function handleError(err: Error) {
 const migrationConfig = {
   // We ensure that our Mongoose connection and migration config use the same DB:
   mongodb: {
-    url: appConfig.dbUrl,
-    databaseName: appConfig.dbName,
-    options: appConfig.dbOptions
+    url: appConfig.db.url,
+    databaseName: appConfig.db.name,
+    options: appConfig.db.options
   },
   migrationsDir: "server/migrations",
   changelogCollectionName: "changelog",


### PR DESCRIPTION
Changed the recovery password text as stated in Issue #70.
![image](https://user-images.githubusercontent.com/43684531/93208137-13237780-f72a-11ea-8dbd-1ee8b19bcd81.png)

Refactored db fields into a single db object as stated in Issue #74 
Confirmed that all pages are still operational after refactor and reference changes.