### PR TITLE
Add getEventById action

### DIFF
--- a/server/actions/events.ts
+++ b/server/actions/events.ts
@@ -1,5 +1,6 @@
 import Mongo from "server/index";
 import Event from "server/models/event";
+import errors from "utils/errors";
 import { Event as EventType } from "utils/types";
 
 export async function getUpcomingEvents() {
@@ -37,4 +38,16 @@ export async function getNearestEvents({ lat, long }: Coordinates) {
     .exec();
 
   return result as Promise<EventType[]>;
+}
+
+export async function getEventById(_id: string): Promise<EventType> {
+  await Mongo();
+
+  const event = (await Event.findById(_id).lean()) as EventType;
+
+  if (event == null) {
+    throw new Error(errors.event.INVALID_ID);
+  }
+
+  return event;
 }

--- a/server/models/event.js
+++ b/server/models/event.js
@@ -16,6 +16,10 @@ const pointSchema = new Schema({
 
 // Keep in sync with utils/types Event
 const eventSchema = new Schema({
+  _id: {
+    type: String,
+    default: () => new mongoose.Types.ObjectId().toHexString()
+  },
   name: {
     type: String,
     required: true

--- a/server/models/nonprofit.js
+++ b/server/models/nonprofit.js
@@ -57,7 +57,7 @@ const nonprofitSchema = new Schema({
   events: {
     type: [
       {
-        type: Schema.ObjectId,
+        type: String,
         ref: "Event"
       }
     ],

--- a/utils/errors.ts
+++ b/utils/errors.ts
@@ -12,5 +12,8 @@ export default {
       "A nonprofit with the provided ID does not exist in our database.",
     DONATION_LOG_FAILURE: "Unable to log donation for the nonprofit.",
     NO_DATA: "The database does not contain any nonprofits."
+  },
+  event: {
+    INVALID_ID: "An event with the provided ID does not exist in our database."
   }
 };


### PR DESCRIPTION
Result when passing a valid id:
![get_event_by_id](https://user-images.githubusercontent.com/45107667/93716028-00021480-fb3b-11ea-92b2-0479043367c1.png)

Result when id is not found:
![id_not_found](https://user-images.githubusercontent.com/45107667/93716031-02646e80-fb3b-11ea-9c06-a059c472b773.png)

One issue I ran into when testing this PR was with the event `_id` field. Since this field was previously set as strings in the migration script, the `findById` call could never correctly find an event since this method implicitly casts the string input as an `ObjectId` and thus the comparison between the string and objects were never equal. to fix this, I changed the migration script to set the `_id` field by creating a new `ObjectId` (which is why the id passed into the method and the actual id on the event object returned are different). However, I don't think is a good long-term solution since the id actually stored in the database looks very different. One option is to assign the `_id` field in the schema directly as a string (similar to the nonprofit schema). 

Thoughts? @PC98 