### PR TITLE
Regenerate donate page if the nonprofit id doesn't exist 

### DIFF
--- a/pages/donate/[id].tsx
+++ b/pages/donate/[id].tsx
@@ -1,25 +1,19 @@
 import React from "react";
 import {
   NextPage,
-  GetStaticProps,
   GetStaticPaths,
   InferGetStaticPropsType,
   GetStaticPropsContext
 } from "next";
-
+import ErrorPage from "next/error";
 import { Dropdown } from "utils/types";
-
 import {
   getNonprofitIds,
   getNonprofitNamesWithIds,
   getNonprofitById
 } from "server/actions/nonprofit";
-
 import DonationPage from "components/donation/DonationPage";
-
 import config from "config";
-import Head from "next/head";
-import ErrorPage from "next/error";
 
 const NonprofitDonationPage: NextPage<InferGetStaticPropsType<
   typeof getStaticProps
@@ -65,7 +59,8 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
     };
   } catch (err) {
     return {
-      props: {}
+      props: {},
+      revalidate: 10
     };
   }
 };

--- a/pages/donate/[id].tsx
+++ b/pages/donate/[id].tsx
@@ -14,11 +14,15 @@ import {
 } from "server/actions/nonprofit";
 import DonationPage from "components/donation/DonationPage";
 import config from "config";
+import { useRouter } from "next/router";
 
 const NonprofitDonationPage: NextPage<InferGetStaticPropsType<
   typeof getStaticProps
 >> = props => {
-  if (props.nonprofit) {
+  const router = useRouter();
+  if (router.isFallback) {
+    return null;
+  } else if (props.nonprofit) {
     return <DonationPage {...props} />;
   } else {
     return <ErrorPage statusCode={404} />;
@@ -31,6 +35,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
   return { paths: ids.map(config.pages.donate), fallback: true };
 };
 
+// eslint-disable-next-line
 export const getStaticProps = async (context: GetStaticPropsContext) => {
   const id = context.params?.id as string;
 

--- a/pages/donate/[id].tsx
+++ b/pages/donate/[id].tsx
@@ -19,24 +19,15 @@ import DonationPage from "components/donation/DonationPage";
 
 import config from "config";
 import Head from "next/head";
-import DefaultErrorPage from "next/error";
+import ErrorPage from "next/error";
 
 const NonprofitDonationPage: NextPage<InferGetStaticPropsType<
   typeof getStaticProps
 >> = props => {
   if (props.nonprofit) {
-    // @ts-ignore temp
     return <DonationPage {...props} />;
   } else {
-    return (
-      <>
-        <Head>
-          <meta name="robots" content="noindex" />
-          <title>404</title>
-        </Head>
-        <DefaultErrorPage statusCode={404} />
-      </>
-    );
+    return <ErrorPage statusCode={404} />;
   }
 };
 
@@ -46,10 +37,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
   return { paths: ids.map(config.pages.donate), fallback: true };
 };
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const getStaticProps: GetStaticProps = async (
-  context: GetStaticPropsContext
-) => {
+export const getStaticProps = async (context: GetStaticPropsContext) => {
   const id = context.params?.id as string;
 
   /* For now, getNonprofitById excludes Nonprofit's donation field. If you were fetching it, ensure

--- a/pages/donate/[id].tsx
+++ b/pages/donate/[id].tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { NextPage, GetStaticProps, GetStaticPaths } from "next";
+import {
+  NextPage,
+  GetStaticProps,
+  GetStaticPaths,
+  InferGetStaticPropsType,
+  GetStaticPropsContext
+} from "next";
 
 import { Dropdown } from "utils/types";
 
@@ -12,41 +18,68 @@ import {
 import DonationPage from "components/donation/DonationPage";
 
 import config from "config";
+import Head from "next/head";
+import DefaultErrorPage from "next/error";
 
-const NonprofitDonationPage: NextPage<React.ComponentProps<
-  typeof DonationPage
->> = props => <DonationPage {...props} />;
+const NonprofitDonationPage: NextPage<InferGetStaticPropsType<
+  typeof getStaticProps
+>> = props => {
+  if (props.nonprofit) {
+    // @ts-ignore temp
+    return <DonationPage {...props} />;
+  } else {
+    return (
+      <>
+        <Head>
+          <meta name="robots" content="noindex" />
+          <title>404</title>
+        </Head>
+        <DefaultErrorPage statusCode={404} />
+      </>
+    );
+  }
+};
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const ids = await getNonprofitIds();
 
-  return { paths: ids.map(config.pages.donate), fallback: false };
+  return { paths: ids.map(config.pages.donate), fallback: true };
 };
 
-export const getStaticProps: GetStaticProps = async ({ params }) => {
-  const id = params?.id as string;
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const getStaticProps: GetStaticProps = async (
+  context: GetStaticPropsContext
+) => {
+  const id = context.params?.id as string;
 
   /* For now, getNonprofitById excludes Nonprofit's donation field. If you were fetching it, ensure
    * that donation IDs are mapped to a string array so that the nonprofit object is JSON serializable. */
-  const [namesWithIds, nonprofit] = await Promise.all([
-    getNonprofitNamesWithIds(),
-    getNonprofitById(id)
-  ]);
+  try {
+    const [namesWithIds, nonprofit] = await Promise.all([
+      getNonprofitNamesWithIds(),
+      getNonprofitById(id)
+    ]);
 
-  const items = namesWithIds.map(
-    ({ _id, name }): Dropdown => ({
-      value: _id,
-      text: name
-    })
-  );
+    const items = namesWithIds.map(
+      ({ _id, name }): Dropdown => ({
+        value: _id,
+        text: name
+      })
+    );
 
-  return {
-    props: {
-      nonprofit,
-      items,
-      selectedValue: id
-    }
-  };
+    return {
+      props: {
+        nonprofit,
+        items,
+        selectedValue: id
+      },
+      revalidate: 10
+    };
+  } catch (err) {
+    return {
+      props: {}
+    };
+  }
 };
 
 export default NonprofitDonationPage;


### PR DESCRIPTION
Fixes #83 
Tested it with making new nonprofits in MongoDB Compass (with a string _id field) and it seems to work properly.