### PR TITLE
changed volunteers field under event schema to be type User

### DIFF
--- a/server/models/event.js
+++ b/server/models/event.js
@@ -67,7 +67,7 @@ const eventSchema = new Schema(
       type: [
         {
           type: Schema.ObjectId,
-          ref: "Admin" //TODO replace with "User" once that schema is created
+          ref: "User"
         }
       ],
       default: []


### PR DESCRIPTION
Pretty sure no migration script is needed, as `volunteers` under current events is just the empty array. Let me know if we need one, though