### PR TITLE
Create event list

### DIFF
--- a/components/core/icons/ChevronLeftIcon.tsx
+++ b/components/core/icons/ChevronLeftIcon.tsx
@@ -1,0 +1,26 @@
+import { SvgIcon } from "@material-ui/core";
+import React from "react";
+
+interface Props {
+  color: string;
+}
+
+const ChevronLeftIcon: React.FC<Props> = ({ color }: Props) => {
+  return (
+    <SvgIcon
+      htmlColor={color}
+      width="17"
+      height="17"
+      viewBox="0 0 17 17"
+      fill="none"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M10.0384 13.2803C9.74549 13.5732 9.27061 13.5732 8.97772 13.2803L4.72772 9.03033C4.43483 8.73744 4.43483 8.26256 4.72772 7.96967L8.97772 3.71967C9.27061 3.42678 9.74549 3.42678 10.0384 3.71967C10.3313 4.01256 10.3313 4.48744 10.0384 4.78033L6.31871 8.5L10.0384 12.2197C10.3313 12.5126 10.3313 12.9874 10.0384 13.2803Z"
+      />
+    </SvgIcon>
+  );
+};
+
+export default ChevronLeftIcon;

--- a/components/core/icons/ChevronLeftIcon.tsx
+++ b/components/core/icons/ChevronLeftIcon.tsx
@@ -5,15 +5,9 @@ interface Props {
   color: string;
 }
 
-const ChevronLeftIcon: React.FC<Props> = ({ color }: Props) => {
+const ChevronLeftIcon: React.FC<Props> = ({ color }) => {
   return (
-    <SvgIcon
-      htmlColor={color}
-      width="17"
-      height="17"
-      viewBox="0 0 17 17"
-      fill="none"
-    >
+    <SvgIcon htmlColor={color} width="17" height="17" viewBox="0 0 17 17">
       <path
         fillRule="evenodd"
         clipRule="evenodd"

--- a/components/core/icons/ChevronRightIcon.tsx
+++ b/components/core/icons/ChevronRightIcon.tsx
@@ -5,15 +5,9 @@ interface Props {
   color: string;
 }
 
-const ChevronRightIcon: React.FC<Props> = ({ color }: Props) => {
+const ChevronRightIcon: React.FC<Props> = ({ color }) => {
   return (
-    <SvgIcon
-      htmlColor={color}
-      width="17"
-      height="17"
-      viewBox="0 0 17 17"
-      fill="none"
-    >
+    <SvgIcon htmlColor={color} width="17" height="17" viewBox="0 0 17 17">
       <path
         fillRule="evenodd"
         clipRule="evenodd"

--- a/components/core/icons/ChevronRightIcon.tsx
+++ b/components/core/icons/ChevronRightIcon.tsx
@@ -1,0 +1,26 @@
+import { SvgIcon } from "@material-ui/core";
+import React from "react";
+
+interface Props {
+  color: string;
+}
+
+const ChevronRightIcon: React.FC<Props> = ({ color }: Props) => {
+  return (
+    <SvgIcon
+      htmlColor={color}
+      width="17"
+      height="17"
+      viewBox="0 0 17 17"
+      fill="none"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M6.47772 3.71967C6.77061 3.42678 7.24549 3.42678 7.53838 3.71967L11.7884 7.96967C12.0813 8.26256 12.0813 8.73744 11.7884 9.03033L7.53838 13.2803C7.24549 13.5732 6.77061 13.5732 6.47772 13.2803C6.18483 12.9874 6.18483 12.5126 6.47772 12.2197L10.1974 8.5L6.47772 4.78033C6.18483 4.48744 6.18483 4.01256 6.47772 3.71967Z"
+      />
+    </SvgIcon>
+  );
+};
+
+export default ChevronRightIcon;

--- a/components/events/EventCardGlimmerLarge.tsx
+++ b/components/events/EventCardGlimmerLarge.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import clsx from "clsx";
+
+import makeStyles from "@material-ui/core/styles/makeStyles";
+import Typography from "@material-ui/core/Typography";
+import { Skeleton } from "@material-ui/lab";
+
+const useStyles = makeStyles({
+  card: {
+    width: 248,
+    height: 267,
+    borderRadius: 10,
+    overflow: "hidden",
+    backgroundColor: "#FFFFFF",
+    /* 1px borders don't play nice on Chrome, so we use an equivalent
+     * box-shadow and wrap the div in another div */
+    boxShadow: "0 0 0 1px #F0F0F0"
+  },
+  cardContainer: {
+    width: 250,
+    height: 269,
+    padding: 1
+  },
+  image: {
+    display: "block",
+    height: 128,
+    width: "inherit",
+    objectFit: "cover"
+  },
+  content: {
+    padding: "16px 24px"
+  },
+  header: {
+    color: "#333333",
+    fontFamily: "Visby CF, sans-serif",
+    fontSize: 16,
+    fontWeight: 800,
+    lineHeight: "130%",
+    marginBottom: 6,
+    /* line-clamp isn't supported yet, so the next four rules handle it for us */
+    display: "-webkit-box",
+    WebkitBoxOrient: "vertical",
+    WebkitLineClamp: 2,
+    overflow: "hidden"
+  },
+  body: {
+    color: "#666666",
+    fontFamily: "Open Sans, sans-serif",
+    fontSize: 16,
+    lineHeight: "150%",
+    marginBottom: 6
+  },
+  meta: {
+    color: "#FD8033",
+    fontFamily: "Visby CF, sans-serif",
+    fontSize: 16,
+    fontWeight: 800,
+    lineHeight: "130%",
+    marginBottom: 6
+  },
+  /* Only works for truncating a single line */
+  truncate: {
+    textOverflow: "ellipsis",
+    overflow: "hidden",
+    whiteSpace: "nowrap"
+  }
+});
+
+const EventCardGlimmerLarge: React.FC = () => {
+  const {
+    card,
+    cardContainer,
+    content,
+    image,
+    meta,
+    body,
+    header,
+    truncate
+  } = useStyles();
+
+  return (
+    <div className={cardContainer}>
+      <div className={card}>
+        <Skeleton animation="wave" className={image} variant="rect" />
+        <div className={content}>
+          <Typography className={clsx(meta, truncate)}>
+            <Skeleton />
+          </Typography>
+          <Typography className={header}>
+            <Skeleton />
+          </Typography>
+          <Typography className={clsx(body, truncate)}>
+            <Skeleton />
+          </Typography>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EventCardGlimmerLarge;

--- a/components/events/EventsList.tsx
+++ b/components/events/EventsList.tsx
@@ -1,0 +1,152 @@
+import React, { useEffect, useState } from "react";
+
+import makeStyles from "@material-ui/core/styles/makeStyles";
+import { IconButton } from "@material-ui/core";
+import EventCardLarge from "./EventCardLarge";
+import EventCardGlimmerLarge from "./EventCardGlimmerLarge";
+import ChevronRightIcon from "@horizon/icons/ChevronRightIcon";
+import ChevronLeftIcon from "@horizon/icons/ChevronLeftIcon";
+
+const useStyles = makeStyles({
+  button: {
+    backgroundColor: "white",
+    boxShadow: "inset 0 0 0 1px #F0F0F0",
+    "&:hover": {
+      backgroundColor: "#f5f5f5"
+    }
+  },
+  nextButtonContainer: {
+    marginLeft: -24,
+    // boxShadow: "0px 5px 10px rgba(0, 0, 0, 0.05)",
+    borderRadius: "50%"
+  },
+  prevButtonContainer: {
+    marginLeft: 8,
+    marginRight: -56,
+    borderRadius: "50%",
+    position: "relative",
+    zIndex: 1
+  },
+  container: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    position: "relative",
+    marginLeft: -32
+  },
+  item: {
+    marginLeft: 32
+  }
+});
+
+interface EventDisplay {
+  name: string;
+  nonprofitName: string;
+  time: string;
+  imagePath: string;
+}
+
+const maxData = 14;
+let dataIndex = 0;
+const mockData = (i: number) => {
+  return {
+    name: `Feeding ${i + 1} Pigeon${i !== 0 ? "s" : ""} in the Park`,
+    nonprofitName: "Pigeon Feeders International",
+    time: "Sunday Morning",
+    imagePath: "defaultImages/defaultEvent.png"
+  };
+};
+
+const getEvents = async (): Promise<[EventDisplay[], boolean]> => {
+  // mock a server response lol
+  await new Promise(r => setTimeout(r, 1000));
+  const out = [];
+  for (let i = 0; i < 4 && dataIndex < maxData; i++) {
+    out.push(mockData(dataIndex));
+    dataIndex++;
+  }
+  return [out, dataIndex < maxData];
+};
+
+const EventsList: React.FC = () => {
+  const classes = useStyles();
+
+  const [events, setEvents] = useState<EventDisplay[]>([]);
+  const [numEvents, setNumEvents] = useState(0);
+  const [page, setPage] = useState(0);
+  const [maxPage, setMaxPage] = useState<number | undefined>();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if ((page + 1) * 4 > numEvents) {
+      void (async () => {
+        setLoading(true);
+        const [newEvents, hasMore] = await getEvents();
+        if (!hasMore) {
+          setMaxPage(page);
+        }
+        setEvents(prevEvents => [...prevEvents, ...newEvents]);
+        setNumEvents(n => n + 4);
+        setLoading(false);
+      })();
+    }
+  }, [numEvents, page]);
+
+  const nextPage = () => {
+    setPage(page + 1);
+  };
+
+  const prevPage = () => {
+    setPage(page - 1);
+  };
+
+  const display: (EventDisplay | null)[] = events.slice(page * 4, page * 4 + 4);
+  if (maxPage == null) {
+    while (display.length < 4) {
+      display.push(null);
+    }
+  }
+
+  return (
+    <div className={classes.container}>
+      {page > 0 && (
+        <div className={classes.prevButtonContainer}>
+          <IconButton
+            aria-label="previous events"
+            className={classes.button}
+            onClick={prevPage}
+          >
+            <ChevronLeftIcon color="#1A1A1A" />
+          </IconButton>
+        </div>
+      )}
+      {display.map((event, i) => (
+        <div className={classes.item} key={i}>
+          {event != null ? (
+            <EventCardLarge
+              headerText={event.name}
+              bodyText={event.nonprofitName}
+              metaText={event.time}
+              imagePath={event.imagePath}
+            />
+          ) : (
+            <EventCardGlimmerLarge />
+          )}
+        </div>
+      ))}
+      {(maxPage == null || page < maxPage) && !loading && (
+        <div className={classes.nextButtonContainer}>
+          <IconButton
+            aria-label="next events"
+            className={classes.button}
+            onClick={nextPage}
+          >
+            <ChevronRightIcon color="#1A1A1A" />
+          </IconButton>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EventsList;

--- a/components/events/EventsList.tsx
+++ b/components/events/EventsList.tsx
@@ -16,13 +16,13 @@ const useStyles = makeStyles({
     }
   },
   nextButtonContainer: {
-    marginLeft: -24,
+    marginLeft: -56,
     // boxShadow: "0px 5px 10px rgba(0, 0, 0, 0.05)",
     borderRadius: "50%"
   },
   prevButtonContainer: {
-    marginLeft: 8,
-    marginRight: -56,
+    marginLeft: -24,
+    marginRight: -24,
     borderRadius: "50%",
     position: "relative",
     zIndex: 1
@@ -31,11 +31,10 @@ const useStyles = makeStyles({
     display: "flex",
     flexDirection: "row",
     alignItems: "center",
-    position: "relative",
-    marginLeft: -32
+    position: "relative"
   },
   item: {
-    marginLeft: 32
+    marginRight: 32
   }
 });
 

--- a/components/events/EventsList.tsx
+++ b/components/events/EventsList.tsx
@@ -83,30 +83,28 @@ const EventsList: React.FC = () => {
   const [transitionDir, setTransitionDir] = useState<-1 | 0 | 1>(0);
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const fetchTimeoutRef = useRef<number>();
+  const fetchingRef = useRef<boolean>(false);
   const resizeTimeoutRef = useRef<number>();
 
   useEffect(() => {
-    if (first + rowSize > numEvents) {
-      clearTimeout(fetchTimeoutRef.current);
-
-      fetchTimeoutRef.current = window.setTimeout(() => {
-        void (async () => {
-          console.log(
-            `first: ${first}\nrowSize: ${rowSize}\nnumEvents: ${numEvents}`
-          );
-          setLoading(true);
-          const fetchNum = first + rowSize - numEvents;
-          const [newEvents, hasMore] = await getEvents(fetchNum);
-          if (!hasMore) {
-            setMaxElem(numEvents + newEvents.length);
-          }
-          setEvents(prevEvents => [...prevEvents, ...newEvents]);
-          setNumEvents(n => n + fetchNum);
-          setLoading(false);
-          setTransitionDir(0);
-        })();
-      }, 100);
+    if (first + rowSize > numEvents && !fetchingRef.current) {
+      void (async () => {
+        fetchingRef.current = true;
+        console.log(
+          `first: ${first}\nrowSize: ${rowSize}\nnumEvents: ${numEvents}`
+        );
+        setLoading(true);
+        const fetchNum = first + rowSize - numEvents;
+        const [newEvents, hasMore] = await getEvents(fetchNum);
+        if (!hasMore) {
+          setMaxElem(numEvents + newEvents.length);
+        }
+        setEvents(prevEvents => [...prevEvents, ...newEvents]);
+        setNumEvents(n => n + fetchNum);
+        setLoading(false);
+        setTransitionDir(0);
+        fetchingRef.current = false;
+      })();
     }
   }, [numEvents, first, rowSize]);
 

--- a/components/events/EventsList.tsx
+++ b/components/events/EventsList.tsx
@@ -34,7 +34,10 @@ const useStyles = makeStyles({
     alignItems: "center",
     position: "relative",
     height: 270,
-    overflowX: "visible"
+    overflowX: "visible",
+    overflowY: "hidden",
+    marginLeft: -24,
+    paddingLeft: 24
   },
   item: {
     marginRight: 32
@@ -80,7 +83,6 @@ const EventsList: React.FC = () => {
   const [rowSize, setRowSize] = useState(4);
   const [maxElem, setMaxElem] = useState(-1);
   const [loading, setLoading] = useState(false);
-  const [transitionDir, setTransitionDir] = useState<-1 | 0 | 1>(0);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const fetchingRef = useRef<boolean>(false);
@@ -102,7 +104,6 @@ const EventsList: React.FC = () => {
         setEvents(prevEvents => [...prevEvents, ...newEvents]);
         setNumEvents(n => n + fetchNum);
         setLoading(false);
-        setTransitionDir(0);
         fetchingRef.current = false;
       })();
     }
@@ -113,9 +114,10 @@ const EventsList: React.FC = () => {
     const w = containerRef.current?.offsetWidth;
     resizeTimeoutRef.current = window.setTimeout(() => {
       if (w != null) {
-        setRowSize(Math.max(1, Math.floor(w / 301)));
+        console.log(w);
+        setRowSize(Math.max(1, Math.floor((w - 24) / 283)));
       }
-    }, 250);
+    }, 100);
   }, []);
 
   // add an event listener and call the initial row size calibration
@@ -129,12 +131,10 @@ const EventsList: React.FC = () => {
 
   const nextPage = () => {
     setFirst(first + rowSize);
-    setTransitionDir(1);
   };
 
   const prevPage = () => {
     setFirst(Math.max(first - rowSize, 0));
-    setTransitionDir(-1);
   };
 
   const display: (EventDisplay | null)[] = events.slice(first, first + rowSize);

--- a/components/events/EventsList.tsx
+++ b/components/events/EventsList.tsx
@@ -1,11 +1,4 @@
-import React, {
-  createRef,
-  RefObject,
-  useEffect,
-  useState,
-  useRef,
-  useCallback
-} from "react";
+import React, { useEffect, useState, useRef, useCallback } from "react";
 
 import makeStyles from "@material-ui/core/styles/makeStyles";
 import { IconButton } from "@material-ui/core";
@@ -84,9 +77,7 @@ const EventsList: React.FC = () => {
   const [events, setEvents] = useState<EventDisplay[]>([]);
   const [numEvents, setNumEvents] = useState(0);
   const [first, setFirst] = useState(0);
-  const [resized, setResized] = useState(true);
   const [rowSize, setRowSize] = useState(4);
-  const [elRefs, setElRefs] = useState<RefObject<HTMLDivElement>[]>([]);
   const [maxElem, setMaxElem] = useState(-1);
   const [loading, setLoading] = useState(false);
   const [transitionDir, setTransitionDir] = useState<-1 | 0 | 1>(0);
@@ -119,44 +110,24 @@ const EventsList: React.FC = () => {
     }
   }, [numEvents, first, rowSize]);
 
-  // useEffect(() => {
-  //   console.log("changing elRefs");
-  //   // add or remove refs
-  //   setElRefs(elRefs =>
-  //     Array(rowSize)
-  //       .fill(0)
-  //       .map((_, i) => elRefs[i] || createRef())
-  //   );
-  //   setResized(false);
-  // }, [resized]);
-
   const handleResize = useCallback(() => {
     clearTimeout(resizeTimeoutRef.current);
     const w = containerRef.current?.offsetWidth;
     resizeTimeoutRef.current = window.setTimeout(() => {
-      setResized(true);
       if (w != null) {
-        setRowSize(Math.floor(w / 301));
+        setRowSize(Math.max(1, Math.floor(w / 301)));
       }
     }, 250);
   }, []);
 
+  // add an event listener and call the initial row size calibration
   useEffect(() => {
     window.addEventListener("resize", handleResize);
+    handleResize();
     return () => {
       window.removeEventListener("resize", handleResize);
     };
   }, [handleResize]);
-
-  // useEffect(() => {
-  //   console.log("changing rowSize");
-  //   const firstWrap = elRefs.findIndex(
-  //     (ref, i) => ref.current?.offsetLeft === 0 && i !== 0
-  //   );
-  //   if (firstWrap !== -1) {
-  //     setRowSize(firstWrap);
-  //   }
-  // }, [elRefs]);
 
   const nextPage = () => {
     setFirst(first + rowSize);
@@ -189,7 +160,7 @@ const EventsList: React.FC = () => {
         </div>
       )}
       {display.map((event, i) => (
-        <div className={classes.item} key={i} ref={elRefs[i]}>
+        <div className={classes.item} key={i}>
           {event != null ? (
             <EventCardLarge
               headerText={event.name}

--- a/components/events/EventsPage.tsx
+++ b/components/events/EventsPage.tsx
@@ -18,7 +18,7 @@ const EventsPage: React.FC<Props> = props => {
         />
       }
     >
-        <div style={{ padding: 64 }}>
+        <div style={{ padding: 64, width: "100%" }}>
           <EventsList />
         </div>
     </EventsPageLayout>

--- a/components/events/EventsPage.tsx
+++ b/components/events/EventsPage.tsx
@@ -18,9 +18,9 @@ const EventsPage: React.FC<Props> = props => {
         />
       }
     >
-        <div style={{ padding: 64, width: "100%" }}>
-          <EventsList />
-        </div>
+      <div style={{ padding: 64, width: "100%" }}>
+        <EventsList />
+      </div>
     </EventsPageLayout>
   );
 };

--- a/components/events/EventsPage.tsx
+++ b/components/events/EventsPage.tsx
@@ -4,12 +4,21 @@ import EventsPageLeftRailComponent from "./EventsPageLeftRailComponent";
 import EventsList from "./EventsList";
 
 import { Dropdown } from "utils/types";
+import { makeStyles } from "@material-ui/core";
+
+const useStyles = makeStyles({
+  container: {
+    padding: 64,
+    width: "100%"
+  }
+});
 
 interface Props {
   causesFilterOptions: Dropdown[];
 }
 
 const EventsPage: React.FC<Props> = props => {
+  const classes = useStyles();
   return (
     <EventsPageLayout
       sidebarComponent={
@@ -18,7 +27,7 @@ const EventsPage: React.FC<Props> = props => {
         />
       }
     >
-      <div style={{ padding: 64, width: "100%" }}>
+      <div className={classes.container}>
         <EventsList />
       </div>
     </EventsPageLayout>

--- a/components/events/EventsPage.tsx
+++ b/components/events/EventsPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import EventsPageLayout from "components/events/EventsPageLayout";
 import EventsPageLeftRailComponent from "./EventsPageLeftRailComponent";
+import EventsList from "./EventsList";
 
 import { Dropdown } from "utils/types";
 
@@ -17,7 +18,9 @@ const EventsPage: React.FC<Props> = props => {
         />
       }
     >
-      {null}
+        <div style={{ padding: 64 }}>
+          <EventsList />
+        </div>
     </EventsPageLayout>
   );
 };


### PR DESCRIPTION
Closes #156

`EventsList.tsx` shows a responsive number of event cards (max 4), supporting pagination but not animations.

https://streamable.com/w8sqqy
https://streamable.com/x9rlsc

### Display/Navigation

There are three key pieces of state at play:
- `events`, the array of event information
- `rowSize`, the number of events per row
- `first`, the index of the first element displayed

We want to display elements at indices `[first ... first + rowSize]`. If we still need elements, then we make a request to the server for more items and pad the row with glimmers.  If we don't have any more elements to display (based on `maxElem`), then we don't render any glimmers.

Pressing the previous button moves `first` to `first - rowSize` (or 0 if it becomes negative). Pressing the next button moves `first` to `first + rowSize`.

### Pagination

When we need to show more elements (`first + rowSize > maxElem`), we fetch as many elements as needed to fill the row using `getEvents()`. `getEvents()` is called in an async IIFE. After it is called, we update `events` with the data and set `maxElem` if the server tells us no more elements are available. We also use `fetchingRef` to make sure only one call to the server happens at a time.

### Responsivity

On resize (and on component mount), we grab the size of the container element and do math to figure out how many cards we can fit in given space. We set `rowSize` accordingly (this may or may not trigger a fetch). The resize callback is wrapped in a debounce to make sure we don't update state too much.

Because of the total delay between resize and `rowSize` being updated (debounce + state update), we set the container to wrap and hide the y-overflow so the component retains the expected height at all times.

### Future Work

- Slide animations (React Transition Group will probably be the way to go)
- Pass `getEvents` as a prop so we can reuse the component and not use mock data


### Other Changes
- Add `ChevronLeftIcon` and `ChevronRightIcon` from Horizon's icon set
- Add `EventCardGlimmerLarge` by copying `EventCardLarge` and replacing content with Material UI's `Skeleton` component
- Use `EventList` in a container `div` in `EventsPage`