### PR TITLE
Update cause card styling

### DIFF
--- a/components/events/EventsPageCauseCard.tsx
+++ b/components/events/EventsPageCauseCard.tsx
@@ -8,14 +8,15 @@ import { CauseCardData } from "utils/types";
 
 interface StyleProps {
   imagePath: string;
+  isSmall: boolean;
 }
 
 const useStyles = makeStyles<Theme, StyleProps>(({ palette }: Theme) =>
   createStyles({
     card: {
       backgroundColor: palette.background.paper,
-      width: 246,
-      height: 138,
+      width: props => (props.isSmall ? 250 : 360),
+      height: props => (props.isSmall ? 138 : 202),
       borderRadius: 10,
       overflow: "hidden",
       outline: "none",
@@ -38,20 +39,32 @@ const useStyles = makeStyles<Theme, StyleProps>(({ palette }: Theme) =>
 interface Props {
   causeCardData: CauseCardData;
   onClick: () => void;
+  isSmall?: boolean;
 }
 
-const EventsPageCauseCard: React.FC<Props> = ({ causeCardData, onClick }) => {
+const EventsPageCauseCard: React.FC<Props> = ({
+  causeCardData,
+  onClick,
+  isSmall = false
+}) => {
   const { imagePath, cause } = causeCardData;
   const { card, causeText } = useStyles({
-    imagePath
+    imagePath,
+    isSmall
   });
 
   return (
     <FocusVisibleOnly onClick={onClick}>
       <div className={card}>
-        <CoreTypography variant="h2" className={causeText}>
-          {cause}
-        </CoreTypography>
+        {isSmall ? (
+          <CoreTypography variant="h4" className={causeText}>
+            {cause}
+          </CoreTypography>
+        ) : (
+          <CoreTypography variant="h2" className={causeText}>
+            {cause}
+          </CoreTypography>
+        )}
       </div>
     </FocusVisibleOnly>
   );

--- a/components/events/EventsPageCauseCard.tsx
+++ b/components/events/EventsPageCauseCard.tsx
@@ -6,40 +6,31 @@ import CoreTypography from "@core/typography";
 import FocusVisibleOnly from "components/FocusVisibleOnly";
 import { CauseCardData } from "utils/types";
 
-const useStyles = makeStyles(({ palette }: Theme) =>
+interface StyleProps {
+  imagePath: string;
+}
+
+const useStyles = makeStyles<Theme, StyleProps>(({ palette }: Theme) =>
   createStyles({
     card: {
       backgroundColor: palette.background.paper,
-      width: 358,
-      height: 200,
+      width: 246,
+      height: 138,
       borderRadius: 10,
       overflow: "hidden",
-      boxShadow: `0 0 0 1px ${palette.object.lightOutline}`,
-      outline: "none"
-    },
-    cardContainer: {
-      position: "relative",
-      width: 360,
-      height: 202,
-      padding: 1
-    },
-    image: {
-      display: "block",
-      width: "inherit",
-      objectFit: "cover"
-    },
-    textContainer: {
-      position: "absolute",
-      width: 280,
-      height: 68,
-      left: "calc(50% - 280px/2)",
-      top: "calc(50% - 68px/2)"
+      outline: "none",
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundImage: props => `url(${props.imagePath})`
     },
     causeText: {
       color: palette.primary.contrastText,
       display: "flex",
       alignItems: "center",
-      textAlign: "center"
+      textAlign: "center",
+      maxWidth: 260
     }
   })
 );
@@ -50,23 +41,19 @@ interface Props {
 }
 
 const EventsPageCauseCard: React.FC<Props> = ({ causeCardData, onClick }) => {
-  const { card, cardContainer, textContainer, image, causeText } = useStyles();
-
   const { imagePath, cause } = causeCardData;
+  const { card, causeText } = useStyles({
+    imagePath
+  });
 
   return (
-    <div className={cardContainer}>
-      <FocusVisibleOnly onClick={onClick}>
-        <div className={card}>
-          <img src={imagePath} className={image} alt={`${cause}`} />
-          <div className={textContainer}>
-            <CoreTypography variant="h2" className={causeText}>
-              {cause}
-            </CoreTypography>
-          </div>
-        </div>
-      </FocusVisibleOnly>
-    </div>
+    <FocusVisibleOnly onClick={onClick}>
+      <div className={card}>
+        <CoreTypography variant="h2" className={causeText}>
+          {cause}
+        </CoreTypography>
+      </div>
+    </FocusVisibleOnly>
   );
 };
 

--- a/components/events/EventsPageCauseList.tsx
+++ b/components/events/EventsPageCauseList.tsx
@@ -33,9 +33,9 @@ const EventsPageCauseList: React.FC = () => {
           onClick={() => {
             put(cardData.filterValue);
           }}
+          isSmall
         />
       )}
-      cardWidth={358}
     />
   );
 };


### PR DESCRIPTION
Closes #307 

This change centers text in the cause card
We also add the `isSmall` prop to handle the two sizes in the Figma, defaulting to the large size