### PR TITLE
Fetch less information about a nonprofit from event page

### DIFF
--- a/components/events/description/EventsPageDescriptionDetailsBox.tsx
+++ b/components/events/description/EventsPageDescriptionDetailsBox.tsx
@@ -15,7 +15,7 @@ import {
 import CoreLink from "@core/link";
 import CoreTypography from "@core/typography";
 import { formatDateRange } from "utils/date";
-import { Event, Nonprofit } from "utils/types";
+import { Event, NonprofitInfoForEventPage } from "utils/types";
 
 const useStyles = makeStyles(({ palette }: Theme) =>
   createStyles({
@@ -53,12 +53,12 @@ const useStyles = makeStyles(({ palette }: Theme) =>
 
 interface Props {
   event: Event;
-  nonProfit: Nonprofit;
+  nonProfitInfo: NonprofitInfoForEventPage;
 }
 
 const EventsPageDescriptionDetailsBox: React.FC<Props> = ({
   event,
-  nonProfit
+  nonProfitInfo
 }: Props) => {
   const classes = useStyles();
   return (
@@ -90,7 +90,7 @@ const EventsPageDescriptionDetailsBox: React.FC<Props> = ({
         <HeartIcon />
         <div style={{ flexDirection: "column" }}>
           <CoreTypography variant="h5">Hosted by</CoreTypography>
-          <CoreTypography variant="h4">{nonProfit.name}</CoreTypography>
+          <CoreTypography variant="h4">{nonProfitInfo.name}</CoreTypography>
         </div>
       </div>
       <CoreButton className={classes.signUp} variant="contained">

--- a/components/events/description/EventsPageDescriptionMainContent.tsx
+++ b/components/events/description/EventsPageDescriptionMainContent.tsx
@@ -6,7 +6,7 @@ import { CoreButtonWithLongArrow } from "@core/buttons";
 import CoreDivider from "@core/divider";
 import CoreTypography from "@core/typography";
 import { formatDateRange } from "utils/date";
-import { Nonprofit, Event } from "utils/types";
+import { Event, NonprofitInfoForEventPage } from "utils/types";
 
 import EventsPageDescriptionImage from "./EventsPageDescriptionImage";
 
@@ -43,10 +43,10 @@ const useStyles = makeStyles(({ palette }: Theme) =>
 
 interface Props {
   event: Event;
-  nonProfit: Nonprofit;
+  nonProfitInfo: NonprofitInfoForEventPage;
 }
 
-const EventsPageDescriptionMainContent = ({ event, nonProfit }: Props) => {
+const EventsPageDescriptionMainContent = ({ event, nonProfitInfo }: Props) => {
   const classes = useStyles();
 
   return (
@@ -69,10 +69,10 @@ const EventsPageDescriptionMainContent = ({ event, nonProfit }: Props) => {
         {event.about}
       </CoreTypography>
       <CoreTypography variant="h3" className={classes.aboutHeader}>
-        About {nonProfit.name}
+        About {nonProfitInfo.name}
       </CoreTypography>
       <CoreTypography variant="body1" className={classes.nonProfitParagraph}>
-        {nonProfit.about}
+        {nonProfitInfo.about}
       </CoreTypography>
       <div className={classes.buttonRow}>
         <CoreButtonWithLongArrow>

--- a/components/events/description/EventsPageEventDescription.tsx
+++ b/components/events/description/EventsPageEventDescription.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { Container, makeStyles } from "@material-ui/core";
 
-import { Event, Nonprofit } from "utils/types";
+import { Event, NonprofitInfoForEventPage } from "utils/types";
 
 import EventsPageDescriptionDetailsBox from "./EventsPageDescriptionDetailsBox";
 import EventsPageDescriptionMainContent from "./EventsPageDescriptionMainContent";
@@ -24,23 +24,28 @@ const useStyles = makeStyles({
 
 interface Props {
   event: Event;
-  nonProfit: Nonprofit; // TODO: Don't get the entire nonprofit object
-  // figure out a way to get nonprofit info associated with the nonprofit hosting an event
+  nonProfitInfo: NonprofitInfoForEventPage;
 }
 
 const EventsPageDescription: React.FC<Props> = ({
   event,
-  nonProfit
+  nonProfitInfo
 }: Props) => {
   const classes = useStyles();
 
   return (
     <Container className={classes.bigBox}>
       <div className={classes.mainContent}>
-        <EventsPageDescriptionMainContent event={event} nonProfit={nonProfit} />
+        <EventsPageDescriptionMainContent
+          event={event}
+          nonProfitInfo={nonProfitInfo}
+        />
       </div>
 
-      <EventsPageDescriptionDetailsBox event={event} nonProfit={nonProfit} />
+      <EventsPageDescriptionDetailsBox
+        event={event}
+        nonProfitInfo={nonProfitInfo}
+      />
     </Container>
   );
 };

--- a/pages/events/[id].tsx
+++ b/pages/events/[id].tsx
@@ -12,7 +12,7 @@ import { useRouter } from "next/router";
 import EventsPageDescription from "components/events/description/EventsPageEventDescription";
 import config from "config";
 import { getAllEventIds, getEventById } from "server/actions/events";
-import { getNonprofitById } from "server/actions/nonprofit";
+import { getNonprofitInfoForEventPageById } from "server/actions/nonprofit";
 
 const NonprofitEventPage: NextPage<InferGetStaticPropsType<
   typeof getStaticProps
@@ -28,7 +28,10 @@ const NonprofitEventPage: NextPage<InferGetStaticPropsType<
   }
 
   return (
-    <EventsPageDescription event={props.event} nonProfit={props.nonProfit} />
+    <EventsPageDescription
+      event={props.event}
+      nonProfitInfo={props.nonProfitInfo}
+    />
   );
 };
 
@@ -43,12 +46,14 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
 
   try {
     const event = await getEventById(id);
-    const nonProfit = await getNonprofitById(event.nonprofitId);
+    const nonProfitInfo = await getNonprofitInfoForEventPageById(
+      event.nonprofitId
+    );
 
     return {
       props: {
         event,
-        nonProfit
+        nonProfitInfo
       },
       revalidate: config.nextJSPageRegenerationTime
     };

--- a/server/actions/nonprofit.ts
+++ b/server/actions/nonprofit.ts
@@ -66,13 +66,25 @@ export async function getNonprofitById(_id: string): Promise<NonprofitType> {
   return nonprofit;
 }
 
+const NONPROFIT_FIELDS_FOR_EVENT_PAGE: Record<
+  keyof NonprofitInfoForEventPage,
+  1
+> = {
+  name: 1,
+  about: 1,
+  _id: 1
+};
+
 export async function getNonprofitInfoForEventPageById(
   _id: string
 ): Promise<NonprofitInfoForEventPage> {
   await Mongo();
 
   // Exclude donation information for now:
-  const nonprofit = await Nonprofit.findOne({ _id }, { donations: 0 }).lean();
+  const nonprofit = await Nonprofit.findOne(
+    { _id },
+    NONPROFIT_FIELDS_FOR_EVENT_PAGE
+  ).lean();
   if (nonprofit == null) {
     throw new Error(errors.nonprofit.INVALID_ID);
   }
@@ -82,7 +94,7 @@ export async function getNonprofitInfoForEventPageById(
   }
 
   // @ts-ignore: Temporary, until our Nonprofit Mongoose model is typed
-  return { name: nonprofit.name, _id: nonprofit._id, about: nonprofit.about };
+  return nonprofit;
 }
 
 export async function getDefaultNonprofitId(): Promise<string> {

--- a/server/actions/nonprofit.ts
+++ b/server/actions/nonprofit.ts
@@ -4,7 +4,10 @@ import config from "config";
 import Mongo, { stripeConstructor } from "server/index";
 import Nonprofit from "server/models/nonprofit";
 import errors from "utils/errors";
-import { Nonprofit as NonprofitType } from "utils/types";
+import {
+  Nonprofit as NonprofitType,
+  NonprofitInfoForEventPage
+} from "utils/types";
 
 type NonprofitNameWithId = Pick<NonprofitType, "name" | "_id">;
 
@@ -61,6 +64,25 @@ export async function getNonprofitById(_id: string): Promise<NonprofitType> {
 
   // @ts-ignore: Temporary, until our Nonprofit Mongoose model is typed
   return nonprofit;
+}
+
+export async function getNonprofitInfoForEventPageById(
+  _id: string
+): Promise<NonprofitInfoForEventPage> {
+  await Mongo();
+
+  // Exclude donation information for now:
+  const nonprofit = await Nonprofit.findOne({ _id }, { donations: 0 }).lean();
+  if (nonprofit == null) {
+    throw new Error(errors.nonprofit.INVALID_ID);
+  }
+
+  if (Array.isArray(nonprofit)) {
+    throw new Error(errors.GENERIC_TEXT);
+  }
+
+  // @ts-ignore: Temporary, until our Nonprofit Mongoose model is typed
+  return { name: nonprofit.name, _id: nonprofit._id, about: nonprofit.about };
 }
 
 export async function getDefaultNonprofitId(): Promise<string> {

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -23,6 +23,11 @@ export interface Nonprofit {
   // TODO: consider adding the donations field?
 }
 
+export type NonprofitInfoForEventPage = Pick<
+  Nonprofit,
+  "name" | "_id" | "about"
+>;
+
 // Keep in sync with the backend schema
 export interface Donation {
   name: string;


### PR DESCRIPTION
Closes #329 

This PR adds the function `getNonprofitInfoForEventPageById()` to `server/actions/nonprofit.ts`, which returns only the name, about text, and ID of a nonprofit. This return type is `NonprofitInfoForEventPage`, a subtype of the `Nonprofit` interface. We change other usages in event page components accordingly.