### PR TITLE
do not render EventsPageFilteredHeaderSelect when there are 0 results

### DIFF
--- a/components/events/header/EventsPageFilteredHeader.tsx
+++ b/components/events/header/EventsPageFilteredHeader.tsx
@@ -26,12 +26,20 @@ const EventsPageFilteredHeader: React.FC<Props> = ({
 }) => {
   const { header } = useStyles();
 
-  return (
-    <header className={header}>
-      <CoreTypography variant="h2">{resultsLength} results</CoreTypography>
-      <EventsPageFilteredHeaderSelect setPosition={setPosition} />
-    </header>
-  );
+  if (resultsLength > 0) {
+    return (
+      <header className={header}>
+        <CoreTypography variant="h2">{resultsLength} results</CoreTypography>
+        <EventsPageFilteredHeaderSelect setPosition={setPosition} />
+      </header>
+    );
+  } else {
+    return (
+      <header className={header}>
+        <CoreTypography variant="h2">{resultsLength} results</CoreTypography>
+      </header>
+    );
+  }
 };
 
 export default EventsPageFilteredHeader;

--- a/components/events/header/EventsPageFilteredHeader.tsx
+++ b/components/events/header/EventsPageFilteredHeader.tsx
@@ -26,20 +26,14 @@ const EventsPageFilteredHeader: React.FC<Props> = ({
 }) => {
   const { header } = useStyles();
 
-  if (resultsLength > 0) {
-    return (
-      <header className={header}>
-        <CoreTypography variant="h2">{resultsLength} results</CoreTypography>
+  return (
+    <header className={header}>
+      <CoreTypography variant="h2">{resultsLength} results</CoreTypography>
+      {resultsLength > 0 && (
         <EventsPageFilteredHeaderSelect setPosition={setPosition} />
-      </header>
-    );
-  } else {
-    return (
-      <header className={header}>
-        <CoreTypography variant="h2">{resultsLength} results</CoreTypography>
-      </header>
-    );
-  }
+      )}
+    </header>
+  );
 };
 
 export default EventsPageFilteredHeader;


### PR DESCRIPTION
Added check to see if there were zero results, if there were 0 results, EventsPageFilteredHeaderSelect is not rendered.